### PR TITLE
feat(source-generators): add diagnostic for multiple parameters with [Request] attribute

### DIFF
--- a/examples/Lambda.Host.Example.HelloWorld/Program.cs
+++ b/examples/Lambda.Host.Example.HelloWorld/Program.cs
@@ -5,6 +5,6 @@ var builder = LambdaApplication.CreateBuilder();
 
 var lambda = builder.Build();
 
-lambda.MapHandler(([Request] string __input) => __input.ToUpper());
+lambda.MapHandler(([Request] string input1, [Request] string input2) => "hello world");
 
 await lambda.RunAsync();

--- a/src/Lambda.Host.SourceGenerators/AnalyzerReleases.Unshipped.md
+++ b/src/Lambda.Host.SourceGenerators/AnalyzerReleases.Unshipped.md
@@ -5,3 +5,4 @@
  LH0001  | Lambda.Host.Usage | Error    | Multiple method calls detected                
  LH0002  | Lambda.Host.Usage | Error    | Multiple parameters of the same type detected 
  LH0003  | Lambda.Host.Usage | Error    | Parameter name uses reserved prefix           
+ LH0004  | Lambda.Host.Usage | Error    | Multiple parameters use attribute             

--- a/src/Lambda.Host.SourceGenerators/Diagnostics.cs
+++ b/src/Lambda.Host.SourceGenerators/Diagnostics.cs
@@ -32,4 +32,13 @@ internal static class Diagnostics
         DiagnosticSeverity.Error,
         true
     );
+
+    internal static readonly DiagnosticDescriptor MultipleParametersUseAttribute = new(
+        "LH0004",
+        "Multiple parameters use attribute",
+        "Handler method contains multiple parameters that use the '{0}' attribute. Only one parameter can use this attribute.",
+        UsageCategory,
+        DiagnosticSeverity.Error,
+        true
+    );
 }

--- a/src/Lambda.Host.SourceGenerators/MapHandlerSourceOutput.cs
+++ b/src/Lambda.Host.SourceGenerators/MapHandlerSourceOutput.cs
@@ -240,6 +240,22 @@ internal static class MapHandlerSourceOutput
                         )
                     )
             );
+
+            // check for multiple parameters that use the `[Request]` attribute
+            diagnostics.AddRange(
+                invocationInfo
+                    .DelegateInfo.Parameters.Where(p =>
+                        p.Attributes.Any(a => a.Type == AttributeConstants.Request)
+                    )
+                    .Skip(1)
+                    .Select(p =>
+                        Diagnostic.Create(
+                            Diagnostics.MultipleParametersUseAttribute,
+                            p.LocationInfo?.ToLocation(),
+                            AttributeConstants.Request
+                        )
+                    )
+            );
         }
 
         return diagnostics;

--- a/tests/Lambda.Host.SourceGenerators.UnitTests/MapHandlerIncrementalGeneratorDiagnosticTests.cs
+++ b/tests/Lambda.Host.SourceGenerators.UnitTests/MapHandlerIncrementalGeneratorDiagnosticTests.cs
@@ -136,6 +136,33 @@ public class MapHandlerIncrementalGeneratorDiagnosticTests
         }
     }
 
+    [Fact]
+    public void Test_MultipleParametersWithRequestAttribute()
+    {
+        var diagnostics = GenerateDiagnostics(
+            """
+            using Lambda.Host;
+            using Microsoft.Extensions.Hosting;
+
+            var builder = LambdaApplication.CreateBuilder();
+
+            var lambda = builder.Build();
+
+            lambda.MapHandler(([Request] string input1, [Request] string input2) => "hello world");
+
+            await lambda.RunAsync();
+            """
+        );
+
+        diagnostics.Length.Should().Be(1);
+
+        foreach (var diagnostic in diagnostics)
+        {
+            diagnostic.Id.Should().Be("LH0004");
+            diagnostic.Severity.Should().Be(DiagnosticSeverity.Error);
+        }
+    }
+
     private static ImmutableArray<Diagnostic> GenerateDiagnostics(string source)
     {
         var (driver, _) = GeneratorTestHelpers.GenerateFromSource(source);


### PR DESCRIPTION
## Summary
- Adds new diagnostic `LH0004` that detects when multiple parameters use the `[Request]` attribute
- Only one parameter should be allowed to use the `[Request]` attribute in a Lambda handler

## Changes
- Added `MultipleParametersUseAttribute` diagnostic to `Diagnostics.cs`
- Implemented validation logic in `MapHandlerSourceOutput.cs` to check for multiple `[Request]` attributes
- Added test case `Test_MultipleParametersWithRequestAttribute` to verify the diagnostic works correctly
- Updated `AnalyzerReleases.Unshipped.md` with the new diagnostic

## Test plan
- [x] Unit test added and passing
- [x] Diagnostic correctly identifies multiple `[Request]` attributes on parameters
- [x] Error message clearly indicates which attribute is causing the issue

Closes #25