### PR TITLE
ci(github): replace softprops action with gh release upload command

### DIFF
--- a/.github/workflows/publish-to-nuget.yaml
+++ b/.github/workflows/publish-to-nuget.yaml
@@ -57,11 +57,10 @@ jobs:
             --skip-duplicate
 
       - name: Upload packages as release artifacts
-        uses: softprops/action-gh-release@v1
-        with:
-          files: ./nupkg/*.nupkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ./nupkg/*.nupkg --clobber
 
   publish-success:
     needs: publish


### PR DESCRIPTION
## Summary
Replace the external `softprops/action-gh-release` action with inline bash command using `gh` CLI for uploading NuGet packages as release artifacts.

## Changes
- Removed dependency on `softprops/action-gh-release@v1` action
- Replaced with inline `gh release upload` command
- Uses `--clobber` flag to overwrite existing artifacts if needed
- Simplifies workflow by using only terminal commands instead of external actions

## Test plan
- [ ] Verify the next release publishes successfully
- [ ] Confirm NuGet packages are uploaded as release artifacts