### PR TITLE
ci: skip pr build for draft pull requests

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build-and-test:
+    if: github.event.pull_request.draft == false
 
     runs-on: ubuntu-latest
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@
     
     [optional footer(s)]
     ```  
-  - Types: feat, fix, docs, refactor, test, chore
+  - Types: feat, fix, docs, refactor, test, chore, ci
 
 #### 4. Plan Template
 
@@ -84,8 +84,10 @@ When Claude makes commits, ALWAYS follow conventional commits format:
 
 **Types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`
 
-**Scope (optional but recommended):** `host`, `abstractions`, `opentelemetry`, or omit for general
-changes
+**Scope (optional but recommended):** Must be one of: `host`, `abstractions`, `opentelemetry`,
+`deps`, `build`, `ci`, `github`
+
+- Omit scope for general changes
 
 **Examples:**
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A modern .NET framework for building AWS Lambda functions using familiar ASP.NET Core patterns.
 
+[![Main Build](https://github.com/j-d-ha/aws-lambda-host/actions/workflows/main-build.yaml/badge.svg)](https://github.com/j-d-ha/aws-lambda-host/actions/workflows/main-build.yaml)
+[![codecov](https://codecov.io/gh/j-d-ha/aws-lambda-host/graph/badge.svg?token=BWORPTQ0UK)](https://codecov.io/gh/j-d-ha/aws-lambda-host)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=j-d-ha_aws-lambda-host&metric=alert_status&token=9fb519975d91379dcfbc6c13a4bd4207131af6e3)](https://sonarcloud.io/summary/new_code?id=j-d-ha_aws-lambda-host)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 > ⚠️ **Development Status**: This project is actively under development and not yet
 > production-ready. Breaking changes may occur in future versions. Use at your own discretion in
 > production environments.

--- a/src/AwsLambda.Host.Abstractions/README.md
+++ b/src/AwsLambda.Host.Abstractions/README.md
@@ -1,12 +1,30 @@
 # AwsLambda.Host.Abstractions
 
+Core interfaces and abstractions for the aws-lambda-host framework.
+
+[![Main Build](https://github.com/j-d-ha/aws-lambda-host/actions/workflows/main-build.yaml/badge.svg)](https://github.com/j-d-ha/aws-lambda-host/actions/workflows/main-build.yaml)
+[![codecov](https://codecov.io/gh/j-d-ha/aws-lambda-host/graph/badge.svg?token=BWORPTQ0UK)](https://codecov.io/gh/j-d-ha/aws-lambda-host)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=j-d-ha_aws-lambda-host&metric=alert_status&token=9fb519975d91379dcfbc6c13a4bd4207131af6e3)](https://sonarcloud.io/summary/new_code?id=j-d-ha_aws-lambda-host)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 > ⚠️ **Development Status**: This project is actively under development and not yet
 > production-ready. Breaking changes may occur in future versions. Use at your own discretion in
 > production environments.
 
-Core interfaces and delegates that define the aws-lambda-host framework contract. This package is
-typically used implicitly by [AwsLambda.Host](../AwsLambda.Host/README.md), but useful if you're
-building custom integrations, middleware, or extensions.
+## Overview
+
+Core interfaces and delegates that define the AwsLambda.Host framework contract. This package
+provides:
+
+- **Handler Abstractions**: Interfaces for Lambda request and response handling across different
+  event types
+- **Middleware Contracts**: Abstractions for building and composing middleware components
+- **Dependency Injection**: Service container and lifetime management interfaces
+- **Extension Points**: Contracts for custom integrations and framework extensions
+
+This package is typically used implicitly by [AwsLambda.Host](../AwsLambda.Host/README.md), but is
+essential if you're building custom integrations, middleware components, or extensions to the
+framework.
 
 ## Packages
 
@@ -104,34 +122,6 @@ The abstractions represent three Lambda execution phases:
 - **Shutdown** – `LambdaShutdownDelegate` runs once before termination
 
 For implementation details and examples, see [AwsLambda.Host](../AwsLambda.Host/README.md).
-
-## Installation
-
-Install via NuGet:
-
-```bash
-dotnet add package AwsLambda.Host.Abstractions
-```
-
-Or specify a version:
-
-```bash
-dotnet add package AwsLambda.Host.Abstractions --version <version>
-```
-
-Ensure your project uses C# 11 or later:
-
-```xml
-
-<PropertyGroup>
-  <LangVersion>11</LangVersion>
-  <!-- or <LangVersion>latest</LangVersion> -->
-</PropertyGroup>
-```
-
-> **Note:** This package is typically included automatically when you use
-> [AwsLambda.Host](../AwsLambda.Host/README.md). Direct installation is only necessary when
-> building custom integrations or extensions.
 
 ## Related Packages
 

--- a/src/AwsLambda.Host.OpenTelemetry/README.md
+++ b/src/AwsLambda.Host.OpenTelemetry/README.md
@@ -1,17 +1,35 @@
 # AwsLambda.Host.OpenTelemetry
 
+OpenTelemetry integration for distributed tracing and observability in AWS Lambda functions.
+
+[![Main Build](https://github.com/j-d-ha/aws-lambda-host/actions/workflows/main-build.yaml/badge.svg)](https://github.com/j-d-ha/aws-lambda-host/actions/workflows/main-build.yaml)
+[![codecov](https://codecov.io/gh/j-d-ha/aws-lambda-host/graph/badge.svg?token=BWORPTQ0UK)](https://codecov.io/gh/j-d-ha/aws-lambda-host)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=j-d-ha_aws-lambda-host&metric=alert_status&token=9fb519975d91379dcfbc6c13a4bd4207131af6e3)](https://sonarcloud.io/summary/new_code?id=j-d-ha_aws-lambda-host)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+
 > ⚠️ **Development Status**: This project is actively under development and not yet
 > production-ready. Breaking changes may occur in future versions. Use at your own discretion in
 > production environments.
 
-**AwsLambda.Host.OpenTelemetry** is an extension package for the
-[**AwsLambda.Host**](../AwsLambda.Host/README.md) framework that provides OpenTelemetry
-integration. It wraps the
-[OpenTelemetry.Instrumentation.AWSLambda](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWSLambda)
-package to enable distributed tracing and metrics collection for AWS Lambda functions with
-automatic span creation around invocations. **Requires AwsLambda.Host** – this package extends
-that framework and cannot be used standalone. Built on the OpenTelemetry SDK, it integrates
-seamlessly with the Lambda lifecycle and supports exporting to standard observability backends.
+## Overview
+
+An extension package for the [AwsLambda.Host](../AwsLambda.Host/README.md) framework that provides
+comprehensive observability integration. This package enables:
+
+- **Distributed Tracing**: Automatic span creation and context propagation for Lambda invocations
+- **Metrics Collection**: Performance and business metrics exportable to standard observability
+  backends
+- **OpenTelemetry Integration**: Built on the OpenTelemetry SDK for vendor-neutral instrumentation
+- **AWS Lambda Instrumentation**:
+  Wraps [OpenTelemetry.Instrumentation.AWSLambda](https://www.nuget.org/packages/OpenTelemetry.Instrumentation.AWSLambda)
+  for Lambda-specific insights
+- **Lifecycle Integration**: Seamless integration with Lambda cold starts, warm invocations, and
+  error tracking
+
+**Note**: Requires AwsLambda.Host – this package extends that framework and cannot be used
+standalone. Configure exporters to send traces and metrics to your observability backend (e.g.,
+Datadog, New Relic, Jaeger, CloudWatch).
 
 ## Packages
 

--- a/src/AwsLambda.Host/README.md
+++ b/src/AwsLambda.Host/README.md
@@ -1,12 +1,30 @@
 # AwsLambda.Host
 
+Core framework for building AWS Lambda functions with dependency injection, middleware, and source
+generation.
+
+[![Main Build](https://github.com/j-d-ha/aws-lambda-host/actions/workflows/main-build.yaml/badge.svg)](https://github.com/j-d-ha/aws-lambda-host/actions/workflows/main-build.yaml)
+[![codecov](https://codecov.io/gh/j-d-ha/aws-lambda-host/graph/badge.svg?token=BWORPTQ0UK)](https://codecov.io/gh/j-d-ha/aws-lambda-host)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=j-d-ha_aws-lambda-host&metric=alert_status&token=9fb519975d91379dcfbc6c13a4bd4207131af6e3)](https://sonarcloud.io/summary/new_code?id=j-d-ha_aws-lambda-host)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 > ⚠️ **Development Status**: This project is actively under development and not yet
 > production-ready. Breaking changes may occur in future versions. Use at your own discretion in
 > production environments.
 
-A modern .NET framework for building AWS Lambda functions using familiar ASP.NET Core patterns.
-Provides dependency injection, middleware support, compile-time code generation, and AOT support—all
-optimized for Lambda's execution model.
+## Overview
+
+A modern .NET framework for building AWS Lambda functions using familiar ASP.NET Core patterns. The
+core runtime provides:
+
+- **Dependency Injection**: Built-in service container for managing application dependencies
+- **Middleware Pipeline**: Request/response processing similar to ASP.NET Core middleware
+- **Compile-time Code Generation**: Source generators reduce reflection overhead and improve startup
+  performance
+- **Native AOT Support**: Full compatibility with ahead-of-time compilation for minimal cold starts
+  and reduced package size
+- **Lambda-Optimized Design**: Event handling, cold start reduction, and efficient resource
+  utilization tailored to AWS Lambda constraints
 
 ## Packages
 

--- a/tests/AwsLambda.Host.SourceGenerators.UnitTests/GeneratorTestHelpers.cs
+++ b/tests/AwsLambda.Host.SourceGenerators.UnitTests/GeneratorTestHelpers.cs
@@ -63,9 +63,9 @@ internal static class GeneratorTestHelpers
     {
         var parseOptions = CSharpParseOptions
             .Default.WithLanguageVersion(languageVersion)
-            .WithFeatures(
-                [new KeyValuePair<string, string>("InterceptorsNamespaces", "AwsLambda.Host")]
-            );
+            .WithFeatures([
+                new KeyValuePair<string, string>("InterceptorsNamespaces", "AwsLambda.Host"),
+            ]);
 
         var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions, "InputFile.cs");
 


### PR DESCRIPTION
## Summary
- Add condition to skip build-and-test and code-format jobs when a pull request is in draft status
- Prevents unnecessary CI resource usage until the PR is ready for review

## Changes
- Updated `.github/workflows/pr-build.yaml` to check `github.event.pull_request.draft == false` for both jobs

## Testing
Manual verification that the workflow condition is correctly applied to both jobs