### PR TITLE
chore(github): configure Dependabot to use conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps)"
+      include: "scope"
     groups:
       minor-and-patch:
         update-types:
@@ -16,6 +20,10 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps)"
+      include: "scope"
     groups:
       minor-and-patch:
         update-types:
@@ -27,6 +35,10 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps)"
+      include: "scope"
     groups:
       minor-and-patch:
         update-types:
@@ -37,3 +49,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps)"
+      include: "scope"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## 📋 Summary

Configure Dependabot to create PRs and commits following the conventional commits format. This ensures that dependency updates are properly categorized in release notes and support automatic version bumping.

### Changes Made

1. **Dependabot Configuration** (`.github/dependabot.yml`)
   - Added `commit-message` configuration to all package ecosystems (nuget, github-actions, npm, dotnet-sdk)
   - Uses `chore(deps)` as the commit prefix for all dependency updates
   - Includes scope information for better semantic categorization

2. **Auto-Merge Workflow** (`.github/workflows/dependabot-auto-merge.yml`)
   - Changed merge strategy from `--merge` to `--squash` to ensure clean commit history
   - Squash merges will use the conventional commit message from the PR title

### Benefits

- ✅ Dependency updates follow conventional commits format
- ✅ Release Drafter automatically categorizes updates in the "🔧 Maintenance" section
- ✅ Automatic version bumping now includes dependency updates
- ✅ Cleaner git history with squash merges
- ✅ Consistent with project's commit message requirements

---

## ✅ Checklist

- [x] My changes build cleanly
- [x] I've followed the coding style for this project
- [x] I've tested the changes locally (configuration validated)

---

## 💬 Notes for Reviewers

- Dependabot will now create PRs with titles like `chore(deps): bump package-name from x.y.z to a.b.c`
- When merged, commits will follow the conventional commits format and be properly categorized in release notes
- The `chore(deps)` prefix ensures these updates are treated as patch-level changes in semantic versioning