### PR TITLE
chore(github): update changelog for v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,58 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [Unreleased](https://github.com/j-d-ha/aws-lambda-host/compare/v0.1.3...HEAD)
+## [Unreleased](https://github.com/j-d-ha/aws-lambda-host/compare/v1.0.0...HEAD)
+
+## [v1.0.0](https://github.com/j-d-ha/aws-lambda-host/compare/v0.1.3...v1.0.0) - 2025-11-10
+
+## 🚀 Features
+
+* feat(host): refactor builder entrypoint and improve configuration (#166) @j-d-ha
+* test(source-generators): add comprehensive tests for `HashCode` type (#153) @j-d-ha
+* feat(envelopes): add modular envelope system for Lambda event handling (#131) @j-d-ha
+
+## 🐛 Bug Fixes
+
+* fix: resolve Sonar findings in tests and runtime code (#147) @j-d-ha
+
+## 📚 Documentation
+
+* docs: enhance package README overviews with detailed feature descriptions (#124) @j-d-ha
+
+## 🔄 Refactoring
+
+* refactor(core): refactor lambda application and builder (#163) @j-d-ha
+* refactor(host): reorganize folder structure with hierarchical layers (#146) @j-d-ha
+
+## ✅ Tests
+
+* test(source-generators): add comprehensive tests for `HashCode` type (#153) @j-d-ha
+
+## 🔧 Maintenance
+
+* chore(deps): Bump the minor-and-patch group with 1 update (#165) @[dependabot[bot]](https://github.com/apps/dependabot)
+* chore(github): configure Dependabot to use conventional commits (#164) @j-d-ha
+* chore(deps): bump actions/checkout from 5 to 6 (#158) @[dependabot[bot]](https://github.com/apps/dependabot)
+* chore(deps-dev): bump husky from 8.0.3 to 9.1.7 (#149) @[dependabot[bot]](https://github.com/apps/dependabot)
+* chore(deps-dev): bump @commitlint/cli from 18.6.1 to 20.1.0 (#150) @[dependabot[bot]](https://github.com/apps/dependabot)
+* chore(deps-dev): bump @commitlint/config-conventional from 18.6.3 to 20.0.0 (#151) @[dependabot[bot]](https://github.com/apps/dependabot)
+* feat(opentelemetry): add OpenTelemetry unit tests and update dependencies (#148) @j-d-ha
+* chore(deps-dev): bump js-yaml from 4.1.0 to 4.1.1 in the npm_and_yarn group across 1 directory (#132) @[dependabot[bot]](https://github.com/apps/dependabot)
+* ci: skip workflows for draft pull requests (#127) @j-d-ha
+* ci: skip pr build for draft pull requests (#126) @j-d-ha
+* ci(github): replace softprops action with gh release upload command (#123) @j-d-ha
+* chore(deps): bump amannn/action-semantic-pull-request from 5.4.0 to 6.1.1 (#121) @[dependabot[bot]](https://github.com/apps/dependabot)
+* chore(deps): bump peter-evans/create-pull-request from 5 to 7 (#119) @[dependabot[bot]](https://github.com/apps/dependabot)
+* chore(deps): bump actions/checkout from 4 to 5 (#118) @[dependabot[bot]](https://github.com/apps/dependabot)
+* chore(deps): bump stefanzweifel/git-auto-commit-action from 5 to 7 (#117) @[dependabot[bot]](https://github.com/apps/dependabot)
+* chore(deps): bump release-drafter/release-drafter from 6.0.0 to 6.1.0 in the minor-and-patch group (#116) @[dependabot[bot]](https://github.com/apps/dependabot)
+
+## ⚠️ Breaking Changes
+
+* feat(host): refactor builder entrypoint and improve configuration (#166) @j-d-ha
+* refactor(core): refactor lambda application and builder (#163) @j-d-ha
+* refactor(host): reorganize folder structure with hierarchical layers (#146) @j-d-ha
+* feat(envelopes): add modular envelope system for Lambda event handling (#131) @j-d-ha
 
 ## [v0.1.3](https://github.com/j-d-ha/aws-lambda-host/compare/v0.1.2...v0.1.3) - 2025-11-10
 


### PR DESCRIPTION
## Summary
Updates the CHANGELOG.md file with the v1.0.0 release notes generated by Release Drafter, including all features, fixes, refactoring, tests, and maintenance changes.

## What's Changed
- Updated CHANGELOG.md with v1.0.0 release entries
- Organized changes by category (Features, Bug Fixes, Refactoring, Tests, Maintenance, Breaking Changes)
- Includes all commits from previous release v0.1.3 to v1.0.0

## Notes
This PR is needed because the automated changelog update workflow fails due to branch protection rules on main. This manual update ensures the changelog is up-to-date for the v1.0.0 release.

Resolves the changelog update workflow issue by allowing the changelog to be committed via PR instead of direct push.