### PR TITLE
fix(ci): add write permissions for release asset uploads

### DIFF
--- a/.github/workflows/publish-to-nuget.yaml
+++ b/.github/workflows/publish-to-nuget.yaml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Resolves issue #168 by updating the publish workflow to use `contents: write` permission
- The workflow requires this elevated permission to upload NuGet packages as release artifacts using `gh release upload`

## Changes
- Updated `.github/workflows/publish-to-nuget.yaml` to change permission from `contents: read` to `contents: write`

## Test plan
- [ ] Verify that a new release can be created successfully
- [ ] Confirm that NuGet packages are uploaded as release artifacts without HTTP 403 errors
- [ ] Check that the publish workflow completes successfully from trigger through artifact upload

Closes #168