### PR TITLE
fix(ci): update changelog workflow to create pull request instead of direct commit

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -9,10 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the 
+      # Give the default GITHUB_TOKEN write permission to commit and push the
       # updated CHANGELOG back to the repository.
       # https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -29,9 +30,26 @@ jobs:
       - name: Remove header and summary from CHANGELOG
         run: perl -i -pe 'BEGIN{undef $/} s/(## (?:\[)?v[\d.]+(?:\](?:\([^)]+\))?)? - \d{4}-\d{2}-\d{2}\n)[\s\S]*?### Changes\n+/$1\n/g' CHANGELOG.md
 
-      - name: Commit updated CHANGELOG
-        uses: stefanzweifel/git-auto-commit-action@v7
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
         with:
-          branch: ${{ github.event.release.target_commitish }}
-          commit_message: Update CHANGELOG
-          file_pattern: CHANGELOG.md
+          branch: changelog/${{ github.event.release.tag_name }}
+          base: ${{ github.event.release.target_commitish }}
+          title: "chore: update changelog for ${{ github.event.release.tag_name }}"
+          body: |
+            ## Automated Changelog Update
+
+            This PR updates the CHANGELOG.md file with entries from the release: ${{ github.event.release.tag_name }}
+
+            The changelog was automatically updated by the release workflow.
+          commit-message: "chore: update changelog for ${{ github.event.release.tag_name }}"
+          labels: "automated,changelog,chore"
+          delete-branch: true
+
+      - name: Enable Auto-merge
+        if: steps.cpr.outputs.pull-request-number
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes #169 - The update-changelog workflow now respects branch protection rules by creating a pull request instead of committing directly to main.

## Changes
- Replaced `stefanzweifel/git-auto-commit-action@v7` with `peter-evans/create-pull-request@v6`
- Added `pull-requests: write` permission to the workflow
- Configured auto-squash and auto-merge for the created PR once status checks pass

## How It Works
1. When a release is published, the workflow creates/updates CHANGELOG.md
2. A PR is automatically created with the updated changelog
3. The required `build-and-test` status check runs on the PR
4. Once the check passes, the PR is automatically squashed and merged

## Testing
This will be tested on the next release after this fix is merged.