### PR TITLE
docs: add GitHub issue and discussion templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -1,0 +1,14 @@
+title: 🧵 Open Discussion
+labels: ["discussion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for general thoughts, ideas, or community discussions.
+  - type: textarea
+    id: topic
+    attributes:
+      label: What's on your mind?
+      placeholder: Share your thoughts...
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/idea.yml
+++ b/.github/DISCUSSION_TEMPLATE/idea.yml
@@ -1,0 +1,17 @@
+title: 💡 Idea
+labels: ["💡 idea"]
+body:
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why do you want this?
+      placeholder: Explain the problem or opportunity
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: What's your proposed solution?
+      placeholder: Describe your idea
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/q-and-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-and-a.yml
@@ -1,0 +1,15 @@
+title: ❓ Q&A
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: What is your question?
+      placeholder: Be specific so others can help you quickly
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Library version (if applicable)
+      placeholder: e.g., 1.2.0 or main branch

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,37 @@
+name: 🐛 Bug Report
+description: Report something that isn't working right
+title: "[Bug]: "
+labels: [🐛 bug]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! Please fill out the form below so we can help quickly.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      placeholder: Describe the bug clearly.
+      description: Include what you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: OS, .NET version, browser, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📚 Documentation
+    url: https://github.com/LayeredCraft/.github/wiki
+    about: Please check the documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: ✨ Feature Request
+description: Suggest an idea or improvement
+title: "[Feature]: "
+labels: [💡 idea]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Help us understand your idea!
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      placeholder: Why is this needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      placeholder: Describe the ideal implementation.


### PR DESCRIPTION
## Summary
- Add GitHub issue templates for bug reports and feature requests
- Add GitHub discussion templates for Q&A and announcements

## Test plan
- [x] Templates are properly formatted
- [x] Templates follow GitHub's template conventions