### PR TITLE
docs: update MkDocs palette toggle configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,6 @@ theme:
     - navigation.footer
     - navigation.top
     - navigation.tabs
-    - navigation.tabs.sticky
     - navigation.expand
     - navigation.path
     - navigation.indexes
@@ -32,12 +31,19 @@ theme:
     - content.code.annotate
 
   palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/lightbulb-auto
+        name: Switch to light mode
+    
     # Palette toggle for light mode
     - scheme: default
       primary: orange
       accent: orange
+      media: "(prefers-color-scheme: light)"
       toggle:
-        icon: material/brightness-7
+        icon: material/lightbulb
         name: Switch to dark mode
     
     
@@ -45,8 +51,9 @@ theme:
     - scheme: slate
       primary: black
       accent: orange
+      media: "(prefers-color-scheme: dark)"
       toggle:
-        icon: material/brightness-4
+        icon: material/lightbulb-outline
         name: Switch to light mode
   font:
     code: JetBrains Mono


### PR DESCRIPTION
## Summary

Updates the MkDocs theme configuration to support automatic dark mode detection based on system preferences, along with improved palette toggle icons.

## Changes

- Added automatic dark mode palette option that respects system `prefers-color-scheme` setting
- Updated toggle icons to use lightbulb variants for better visual consistency
- Added media queries to palette configurations for proper light/dark mode detection
- Removed `navigation.tabs.sticky` feature flag

## Type of Change

- [x] Documentation update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

- [x] Verified MkDocs builds successfully with new configuration
- [x] Tested automatic theme switching based on system preferences
- [x] Confirmed manual theme toggle works correctly

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules