### PR TITLE
feat(build): add .NET 11 target support

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -39,6 +39,7 @@ jobs:
             8.0.x
             9.0.x
             10.0.x
+            11.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: 11.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/.github/workflows/publish-to-nuget.yaml
+++ b/.github/workflows/publish-to-nuget.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: 11.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,79 +5,87 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- Packages for all targets -->
-    <PackageVersion Include="Amazon.Lambda.CloudWatchLogsEvents" Version="2.2.1"/>
-    <PackageVersion Include="Amazon.Lambda.Core" Version="2.8.1"/>
-    <PackageVersion Include="Amazon.Lambda.KafkaEvents" Version="2.1.1"/>
-    <PackageVersion Include="Amazon.Lambda.KinesisEvents" Version="3.0.2"/>
-    <PackageVersion Include="Amazon.Lambda.KinesisFirehoseEvents" Version="2.3.1"/>
-    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.14.2"/>
-    <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5"/>
-    <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="11.0.0"/>
-    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1"/>
-    <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0"/>
-    <PackageVersion Include="AWSSDK.Core" Version="4.0.3.20"/>
-    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.4"/>
-    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.4"/>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8"/>
-    <PackageVersion Include="LayeredCraft.SourceGeneratorTools.Generator" Version="0.1.0-beta.10"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.9"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9"/>
-    <PackageVersion Include="Microsoft.AspNetCore.Routing" Version="2.3.9"/>
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.5"/>
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5"/>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201"/>
+    <PackageVersion Include="Amazon.Lambda.CloudWatchLogsEvents" Version="2.2.1" />
+    <PackageVersion Include="Amazon.Lambda.Core" Version="2.8.1" />
+    <PackageVersion Include="Amazon.Lambda.KafkaEvents" Version="2.1.1" />
+    <PackageVersion Include="Amazon.Lambda.KinesisEvents" Version="3.0.2" />
+    <PackageVersion Include="Amazon.Lambda.KinesisFirehoseEvents" Version="2.3.1" />
+    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.14.3" />
+    <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5" />
+    <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="11.0.0" />
+    <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
+    <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.3.20" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net100" Version="1.8.5" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net110" Version="1.8.5" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net80" Version="1.8.5" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="LayeredCraft.SourceGeneratorTools.Generator" Version="0.1.0-beta.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.3.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Routing" Version="2.3.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.202" />
     <!-- Source Gen Libraries -->
-    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis" Version="[5.3.0]"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[5.3.0]"/>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.3"/>
-    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17"/>
-    <PackageVersion Include="PolySharp" Version="1.15.0"/>
-    <PackageVersion Include="Scriban" Version="7.0.6"/>
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis" Version="[5.0.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[5.0.0]" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.3" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+    <PackageVersion Include="PolySharp" Version="1.15.0" />
+    <PackageVersion Include="Scriban" Version="7.1.0" />
     <!-- OTEL Libraries -->
-    <PackageVersion Include="NSubstitute" Version="5.3.0"/>
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.1"/>
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.1"/>
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1"/>
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.15.0"/>
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.15.0" />
     <!-- Testing Libraries -->
-    <PackageVersion Include="AwesomeAssertions" Version="9.4.0"/>
-    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.4"/>
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4"/>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/>
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.5.2"/>
-    <PackageVersion Include="System.Formats.Asn1" Version="6.0.1"/>
-    <PackageVersion Include="System.Net.Http" Version="4.3.4"/>
-    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1"/>
-    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3"/>
-    <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0"/>
-    <PackageVersion Include="Verify.XunitV3" Version="31.15.0"/>
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5"/>
-    <PackageVersion Include="AutoFixture" Version="4.18.1"/>
-    <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1"/>
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.4.0"/>
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="Basic.Reference.Assemblies.Net90" Version="1.8.5" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
+    <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
+    <PackageVersion Include="System.Net.Http" Version="4.3.4" />
+    <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+    <PackageVersion Include="Verify.SourceGenerators" Version="2.5.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="31.16.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="AutoFixture" Version="4.18.1" />
+    <PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.5.0" />
     <!-- Lambda Event Libraries -->
-    <PackageVersion Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3"/>
-    <PackageVersion Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.2.1"/>
-    <PackageVersion Include="Amazon.Lambda.SNSEvents" Version="2.1.1"/>
-    <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="2.2.1"/>
-    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2"/>
+    <PackageVersion Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3" />
+    <PackageVersion Include="Amazon.Lambda.ApplicationLoadBalancerEvents" Version="2.2.1" />
+    <PackageVersion Include="Amazon.Lambda.SNSEvents" Version="2.1.1" />
+    <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="2.2.1" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
   </ItemGroup>
   <!-- Conditional versions based on target framework -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageVersion Include="System.Text.Json" Version="[10.0.5, 11.0.0)"/>
+    <PackageVersion Include="System.Text.Json" Version="[10.0.5, 11.0.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.1, 9.0.0)"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.1, 9.0.0)"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[8.0.1, 9.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[8.0.1, 9.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="[8.0.1, 9.0.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[9.0.14, 10.0.0)"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[9.0.14, 10.0.0)"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[9.0.15, 10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[9.0.15, 10.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="[9.0.15, 10.0.0)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[10.0.5, 11.0.0)"/>
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[10.0.5, 11.0.0)"/>
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[10.0.6, 11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[10.0.6, 11.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="[10.0.6, 11.0.0)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net11.0'">
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="[11.0.0-preview.3.26207.106, 12.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="[11.0.0-preview.3.26207.106, 12.0.0)" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="[11.0.0-preview.3.26207.106, 12.0.0)" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
-//  "sdk": {
-//    "rollForward": "latestMinor",
-//    "version": "10.0.201"
-//  },
+  "sdk": {
+    "rollForward": "latestMinor",
+    "version": "11.0.100-preview.3.26207.106"
+  },
   "test": {
     "runner": "Microsoft.Testing.Platform"
   }

--- a/global.json
+++ b/global.json
@@ -1,8 +1,8 @@
 {
-  "sdk": {
-    "rollForward": "latestMinor",
-    "version": "10.0.201"
-  },
+//  "sdk": {
+//    "rollForward": "latestMinor",
+//    "version": "10.0.201"
+//  },
   "test": {
     "runner": "Microsoft.Testing.Platform"
   }

--- a/src/MinimalLambda.Abstractions/MinimalLambda.Abstractions.csproj
+++ b/src/MinimalLambda.Abstractions/MinimalLambda.Abstractions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/MinimalLambda.OpenTelemetry/MinimalLambda.OpenTelemetry.csproj
+++ b/src/MinimalLambda.OpenTelemetry/MinimalLambda.OpenTelemetry.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0;net11.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/MinimalLambda.Testing/MinimalLambda.Testing.csproj
+++ b/src/MinimalLambda.Testing/MinimalLambda.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/MinimalLambda/MinimalLambda.csproj
+++ b/src/MinimalLambda/MinimalLambda.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/MinimalLambda.Envelopes.UnitTests/MinimalLambda.Envelopes.UnitTests.csproj
+++ b/tests/MinimalLambda.Envelopes.UnitTests/MinimalLambda.Envelopes.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/MinimalLambda.OpenTelemetry.UnitTests/MinimalLambda.OpenTelemetry.UnitTests.csproj
+++ b/tests/MinimalLambda.OpenTelemetry.UnitTests/MinimalLambda.OpenTelemetry.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net10.0;net11.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/MinimalLambda.SourceGenerators.UnitTests/GeneratorTestHelpers.cs
+++ b/tests/MinimalLambda.SourceGenerators.UnitTests/GeneratorTestHelpers.cs
@@ -102,7 +102,9 @@ internal static class GeneratorTestHelpers
 
         List<MetadataReference> references =
         [
-#if NET10_0_OR_GREATER
+#if NET11_0_OR_GREATER
+            .. Net110.References.All.ToList(),
+#elif NET10_0
             .. Net100.References.All.ToList(),
 #elif NET9_0
             .. Net90.References.All.ToList(),

--- a/tests/MinimalLambda.SourceGenerators.UnitTests/MinimalLambda.SourceGenerators.UnitTests.csproj
+++ b/tests/MinimalLambda.SourceGenerators.UnitTests/MinimalLambda.SourceGenerators.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -15,6 +15,7 @@
     <PackageReference Include="AutoFixture"/>
     <PackageReference Include="AwesomeAssertions"/>
     <PackageReference Include="Basic.Reference.Assemblies.Net100"/>
+    <PackageReference Include="Basic.Reference.Assemblies.Net110" />
     <PackageReference Include="Basic.Reference.Assemblies.Net80"/>
     <PackageReference Include="Basic.Reference.Assemblies.Net90"/>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage"/>

--- a/tests/MinimalLambda.Testing.UnitTests/Tests/MinimalLambda.Testing.UnitTests/MinimalLambda.Testing.UnitTests.csproj
+++ b/tests/MinimalLambda.Testing.UnitTests/Tests/MinimalLambda.Testing.UnitTests/MinimalLambda.Testing.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/MinimalLambda.UnitTests/MinimalLambda.UnitTests.csproj
+++ b/tests/MinimalLambda.UnitTests/MinimalLambda.UnitTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;net11.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
# Pull Request

## Summary

This PR adds `net11.0` targeting across the shipped packages and test projects so the repository can build and validate against the current .NET 11 preview SDK. It also updates CI workflow SDK selection and supporting package references needed for the new target framework.

## Checklist

- [x] My changes build cleanly
- [x] I’ve added/updated relevant tests
- [ ] I’ve added/updated documentation or README
- [x] I’ve followed the coding style for this project
- [x] I’ve tested the changes locally (if applicable)

## Notes for Reviewers

- All package and test projects now target `net11.0` in addition to their prior frameworks.
- CI workflows now use .NET 11 where required, and the main build matrix includes `11.0.x`.
- Source generator test helpers now load `Basic.Reference.Assemblies.Net110`, and central package versions were updated to include the new reference assembly package and compatible dependency ranges.
- Local validation: `DOTNET_NOLOGO=1 dotnet test --configuration Release -f net11.0 --no-restore` passed with 841 tests.