### PR TITLE
ci: remove SonarQube integration

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -47,55 +47,12 @@ jobs:
       - name: Install Task
         uses: go-task/setup-task@v2
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: 17
-          distribution: 'zulu'
-
-      - name: Cache SonarQube packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Cache SonarQube scanner
-        id: cache-sonar-scanner
-        uses: actions/cache@v5
-        with:
-          path: ~/.sonar/scanner
-          key: ${{ runner.os }}-sonar-scanner
-          restore-keys: ${{ runner.os }}-sonar-scanner
-
-      - name: Install SonarQube scanner
-        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.sonar/scanner
-          dotnet tool update dotnet-sonarscanner --tool-path ~/.sonar/scanner
-
-      - name: Start SonarQube
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          ~/.sonar/scanner/dotnet-sonarscanner begin \
-            /k:"j-d-ha_minimal-lambda" \
-            /o:"j-d-ha" \
-            /d:sonar.exclusions="**/bin/**,**/obj/**,tests/MinimalLambda.SourceGenerators.UnitTests/Snapshots/**,**/coverage/**,**/.nuget/**,**/packages/**,src/MinimalLambda.Testing/HostFactoryResolver.cs" \
-            /d:sonar.coverage.exclusions="**/*" \
-            /d:sonar.token="$SONAR_TOKEN"
-
       - name: Build
         run: dotnet build --no-restore --configuration Release /p:TreatWarningsAsErrors=true
 
       - name: Run tests
         timeout-minutes: 3
         run: task test:ci
-
-      - name: Stop SonarQube
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ~/.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"
 
       - name: Validate AOT Compatability
         run: task build:aot-check

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -50,55 +50,12 @@ jobs:
       - name: Install Task
         uses: go-task/setup-task@v2
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: 17
-          distribution: 'zulu'
-
-      - name: Cache SonarQube packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Cache SonarQube scanner
-        id: cache-sonar-scanner
-        uses: actions/cache@v5
-        with:
-          path: ~/.sonar/scanner
-          key: ${{ runner.os }}-sonar-scanner
-          restore-keys: ${{ runner.os }}-sonar-scanner
-
-      - name: Install SonarQube scanner
-        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.sonar/scanner
-          dotnet tool update dotnet-sonarscanner --tool-path ~/.sonar/scanner
-
-      - name: Start SonarQube
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          ~/.sonar/scanner/dotnet-sonarscanner begin \
-            /k:"j-d-ha_minimal-lambda" \
-            /o:"j-d-ha" \
-            /d:sonar.exclusions="**/bin/**,**/obj/**,tests/MinimalLambda.SourceGenerators.UnitTests/Snapshots/**,**/coverage/**,**/.nuget/**,**/packages/**,src/MinimalLambda.Testing/HostFactoryResolver.cs" \
-            /d:sonar.coverage.exclusions="**/*" \
-            /d:sonar.token="$SONAR_TOKEN"
-
       - name: Build
         run: dotnet build --no-restore --configuration Release /p:TreatWarningsAsErrors=true
 
       - name: Run tests
         timeout-minutes: 3
         run: task test:ci
-
-      - name: Stop SonarQube
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ~/.sonar/scanner/dotnet-sonarscanner end /d:sonar.token="$SONAR_TOKEN"
 
       - name: Validate AOT Compatability
         run: task build:aot-check

--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,4 @@ nunit-*.xml
 /.cache/
 /.sonarqube/
 /codecov*
-
+**/.venv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,12 @@
 # Contributing to MinimalLambda
 
-Thank you for your interest in contributing to the MinimalLambda project! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to the MinimalLambda project! This document provides
+guidelines and instructions for contributing.
 
 ## Table of Contents
 
 <!-- TOC -->
+
 * [Contributing to MinimalLambda](#contributing-to-minimal-lambda)
   * [Table of Contents](#table-of-contents)
   * [Code of Conduct](#code-of-conduct)
@@ -22,11 +24,13 @@ Thank you for your interest in contributing to the MinimalLambda project! This d
   * [CI/CD Integration](#cicd-integration)
   * [Questions or Need Help?](#questions-or-need-help)
   * [License](#license)
+
 <!-- TOC -->
 
 ## Code of Conduct
 
-We are committed to providing a welcoming and inclusive environment for all contributors. Please be respectful and constructive in all interactions.
+We are committed to providing a welcoming and inclusive environment for all contributors. Please be
+respectful and constructive in all interactions.
 
 ## Getting Started
 
@@ -75,22 +79,26 @@ dotnet clean
 
 ## Code Formatting
 
-Code formatting is automated using **CleanupCode** and **CSharpier**, ensuring consistent style across the project. All PRs are checked for formatting compliance in CI/CD.
+Code formatting is automated using **CleanupCode** and **CSharpier**, ensuring consistent style
+across the project. All PRs are checked for formatting compliance in CI/CD.
 
 ### Formatting Tools
 
 The project uses two complementary tools:
 
 1. **CleanupCode**: JetBrains code cleanup tool
-   - Applies code organization and style rules
-   - Uses the "Built-in: Full Cleanup" profile configured in `MinimalLambda.sln.DotSettings`
-   - Handles code structure and consistency
+
+- Applies code organization and style rules
+- Uses the "Built-in: Full Cleanup" profile configured in `MinimalLambda.sln.DotSettings`
+- Handles code structure and consistency
 
 2. **CSharpier**: Opinionated C# code formatter
-   - Enforces consistent formatting (similar to Prettier for C#)
-   - Handles spacing, line breaks, and code layout
+
+- Enforces consistent formatting (similar to Prettier for C#)
+- Handles spacing, line breaks, and code layout
 
 Tools can be installed using **NuGet**:
+
 ```bash
 dotnet tool restore
 ```
@@ -111,7 +119,7 @@ task format:csharpier
 ```
 
 Always run `task format` before committing changes. Failing to format code may cause CI/CD checks to
-fail, as the GitHub Actions workflow (`pr-build.yaml`) includes a code quality check that runs 
+fail, as the GitHub Actions workflow (`pr-build.yaml`) includes a code quality check that runs
 `task format` and validates no files were modified.
 
 ### IDE Integration
@@ -136,6 +144,7 @@ docs/description                        # Documentation updates
 ```
 
 **Example**:
+
 ```bash
 git checkout -b feature/#42-add-custom-serializer
 git checkout -b bug/on-shutdown-generator-trying-to-return-void
@@ -158,7 +167,8 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/) format:
 - **feat**: A new feature (e.g., `feat(source-generators): add OnShutdown support`)
 - **fix**: A bug fix (e.g., `fix(#73): update MapHandler source generation`)
 - **docs**: Documentation updates (e.g., `docs(openTelemetry): add XML documentation`)
-- **refactor**: Code refactoring without feature changes (e.g., `refactor(source-generators): simplify logic`)
+- **refactor**: Code refactoring without feature changes (e.g.,
+  `refactor(source-generators): simplify logic`)
 - **test**: Adding or updating tests (e.g., `test: add coverage for edge cases`)
 - **chore**: Build, CI/CD, tooling, dependencies (e.g., `chore: update build targets`)
 - **style**: Code style changes without logic changes (e.g., `style: simplify formatting`)
@@ -193,22 +203,25 @@ when using extension method syntax.
    ```
 
 3. **Create a Pull Request** using the [PR template](/.github/pull_request_template.md):
-   - **Title must follow Conventional Commits format** (validated by CI)
-   - Format: `<type>(scope): <description>`
-   - Valid types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `style`
-   - Reference related issues (e.g., `Closes #42`)
-   - Complete the PR template checklist
-   - Request review from maintainers
+
+- **Title must follow Conventional Commits format** (validated by CI)
+- Format: `<type>(scope): <description>`
+- Valid types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `style`
+- Reference related issues (e.g., `Closes #42`)
+- Complete the PR template checklist
+- Request review from maintainers
 
 4. **Respond to feedback**:
-   - Address review comments promptly
-   - Push additional commits to the same branch
-   - Avoid force-pushing after review has started
+
+- Address review comments promptly
+- Push additional commits to the same branch
+- Avoid force-pushing after review has started
 
 5. **Merge**:
-   - Ensure all checks pass (CI/CD, tests, code review)
-   - Maintainer will merge the PR
-   - Your branch will be deleted after merge
+
+- Ensure all checks pass (CI/CD, tests, code review)
+- Maintainer will merge the PR
+- Your branch will be deleted after merge
 
 ## Code Style
 
@@ -223,7 +236,8 @@ when using extension method syntax.
 ### XML Documentation
 
 - **Document all public APIs** with XML documentation tags
-- **Use only standard C# XML tags**: `<summary>`, `<param>`, `<returns>`, `<exception>`, `<remarks>`, `<example>`
+- **Use only standard C# XML tags**: `<summary>`, `<param>`, `<returns>`, `<exception>`,
+  `<remarks>`, `<example>`
 - **Do NOT use unsupported tags** like `<strong>`, `<em>`, etc. (Use `<c>` for code/emphasis)
 - **Example**:
   ```csharp
@@ -359,7 +373,6 @@ All pull requests run through automated checks:
 
 - **Build**: `dotnet build`
 - **Tests**: `dotnet test`
-- **Code analysis**: SonarCloud analysis
 
 Ensure your changes pass all checks before requesting review.
 
@@ -371,7 +384,8 @@ Ensure your changes pass all checks before requesting review.
 
 ## License
 
-By contributing to this project, you agree that your contributions will be licensed under the same MIT License as the project.
+By contributing to this project, you agree that your contributions will be licensed under the same
+MIT License as the project.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Main Build](https://github.com/j-d-ha/minimal-lambda/actions/workflows/main-build.yaml/badge.svg)](https://github.com/j-d-ha/minimal-lambda/actions/workflows/main-build.yaml)
 [![codecov](https://codecov.io/gh/j-d-ha/minimal-lambda/graph/badge.svg?token=BWORPTQ0UK)](https://codecov.io/gh/j-d-ha/minimal-lambda)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=j-d-ha_minimal-lambda&metric=alert_status&token=9fb519975d91379dcfbc6c13a4bd4207131af6e3)](https://sonarcloud.io/summary/new_code?id=j-d-ha_minimal-lambda)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 **Lambda-first hosting with Minimal API-inspired patterns** – Familiar .NET ergonomics with

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,16 @@ title: ""
 
 [![Main Build](https://github.com/j-d-ha/minimal-lambda/actions/workflows/main-build.yaml/badge.svg)](https://github.com/j-d-ha/minimal-lambda/actions/workflows/main-build.yaml)
 [![codecov](https://codecov.io/gh/j-d-ha/minimal-lambda/graph/badge.svg?token=BWORPTQ0UK)](https://codecov.io/gh/j-d-ha/minimal-lambda)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=j-d-ha_minimal-lambda&metric=alert_status&token=9fb519975d91379dcfbc6c13a4bd4207131af6e3)](https://sonarcloud.io/summary/new_code?id=j-d-ha_minimal-lambda)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/j-d-ha/minimal-lambda/blob/main/LICENSE)
 
 **Minimal API-inspired, Lambda-first hosting.**
 
-MinimalLambda keeps the builder, DI, middleware, and handler mapping patterns you know from ASP.NET Core, but is built from the ground up for **any Lambda event source** (SQS, SNS, API Gateway, Kinesis, S3, EventBridge, etc.). Strongly-typed envelopes, lifecycle hooks, scoped invocations, source generation, and cancellation-token handling shape those familiar patterns to Lambda’s execution model—so you get type-safe events, per-invocation scopes, predictable timeouts, and a smoother developer experience when iterating locally or in CI.
+MinimalLambda keeps the builder, DI, middleware, and handler mapping patterns you know from ASP.NET
+Core, but is built from the ground up for **any Lambda event source** (SQS, SNS, API Gateway,
+Kinesis, S3, EventBridge, etc.). Strongly-typed envelopes, lifecycle hooks, scoped invocations,
+source generation, and cancellation-token handling shape those familiar patterns to Lambda’s
+execution model—so you get type-safe events, per-invocation scopes, predictable timeouts, and a
+smoother developer experience when iterating locally or in CI.
 
 [Get Started](getting-started/index.md){ .md-button .md-button--primary }
 [Guides](guides/index.md){ .md-button }
@@ -21,7 +25,8 @@ MinimalLambda keeps the builder, DI, middleware, and handler mapping patterns yo
 
 ## Why MinimalLambda?
 
-Stop wiring up DI scopes, serializers, and cancellation tokens by hand. Ship features with patterns you
+Stop wiring up DI scopes, serializers, and cancellation tokens by hand. Ship features with patterns
+you
 already know, while still embracing Lambda’s execution model.
 
 === "Traditional Lambda"
@@ -174,8 +179,8 @@ await lambda.RunAsync();
 ```
 
 !!! tip "Next Steps"
-    Ready to dive deeper? Check out the [Getting Started Guide](getting-started/index.md) for a complete
-    tutorial, or explore the [Examples](examples/index.md) to see real-world applications.
+Ready to dive deeper? Check out the [Getting Started Guide](getting-started/index.md) for a complete
+tutorial, or explore the [Examples](examples/index.md) to see real-world applications.
 
 ---
 
@@ -186,11 +191,11 @@ await lambda.RunAsync();
 The core packages provide the fundamental hosting framework, abstractions, and observability support
 for building AWS Lambda functions.
 
-| Package                                                          | Description                                   | NuGet                                                                                                                                    | Downloads                                                                                                                                      |
-|------------------------------------------------------------------|-----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| [**MinimalLambda**](https://github.com/j-d-ha/minimal-lambda/tree/main/src/MinimalLambda)                      | Core hosting framework with middleware and DI | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.svg)](https://www.nuget.org/packages/MinimalLambda)                             | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.svg)](https://www.nuget.org/packages/MinimalLambda/)                             |
+| Package                                                                                                             | Description                                   | NuGet                                                                                                                                  | Downloads                                                                                                                                    |
+|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| [**MinimalLambda**](https://github.com/j-d-ha/minimal-lambda/tree/main/src/MinimalLambda)                           | Core hosting framework with middleware and DI | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.svg)](https://www.nuget.org/packages/MinimalLambda)                             | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.svg)](https://www.nuget.org/packages/MinimalLambda/)                             |
 | [**MinimalLambda.Abstractions**](https://github.com/j-d-ha/minimal-lambda/tree/main/src/MinimalLambda.Abstractions) | Core interfaces and contracts                 | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Abstractions.svg)](https://www.nuget.org/packages/MinimalLambda.Abstractions)   | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Abstractions.svg)](https://www.nuget.org/packages/MinimalLambda.Abstractions/)   |
-| [**MinimalLambda.OpenTelemetry**](features/open_telemetry.md)    | Distributed tracing and observability         | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.OpenTelemetry.svg)](https://www.nuget.org/packages/MinimalLambda.OpenTelemetry) | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.OpenTelemetry.svg)](https://www.nuget.org/packages/MinimalLambda.OpenTelemetry/) |
+| [**MinimalLambda.OpenTelemetry**](features/open_telemetry.md)                                                       | Distributed tracing and observability         | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.OpenTelemetry.svg)](https://www.nuget.org/packages/MinimalLambda.OpenTelemetry) | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.OpenTelemetry.svg)](https://www.nuget.org/packages/MinimalLambda.OpenTelemetry/) |
 
 ### Envelope Packages
 
@@ -198,23 +203,23 @@ Envelope packages provide type-safe handling of AWS Lambda event sources with au
 deserialization.
 
 !!! info "What are Envelopes?"
-    Envelopes wrap AWS Lambda events with strongly-typed payload handling, giving you compile-time type
-    safety and automatic deserialization of message bodies from SQS, SNS, Kinesis, and other event
-    sources.
+Envelopes wrap AWS Lambda events with strongly-typed payload handling, giving you compile-time type
+safety and automatic deserialization of message bodies from SQS, SNS, Kinesis, and other event
+sources.
 
     [Learn more about envelopes](features/envelopes.md){ .md-button }
 
-| Package                                                                                | Description                                           | NuGet                                                                                                                                                            | Downloads                                                                                                                                                              |
-|----------------------------------------------------------------------------------------|-------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **MinimalLambda.Envelopes**                              | Infrastructure package for HTTP response builders     | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes)                                 | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes/)                                 |
-| **MinimalLambda.Envelopes.Sqs**                          | Simple Queue Service events with typed message bodies | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Sqs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sqs)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Sqs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sqs/)                         |
-| **MinimalLambda.Envelopes.Sns**                          | Simple Notification Service messages                  | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Sns.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sns)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Sns.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sns/)                         |
-| **MinimalLambda.Envelopes.ApiGateway**           | REST, HTTP, and WebSocket APIs                        | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.ApiGateway.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.ApiGateway)           | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.ApiGateway.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.ApiGateway/)           |
-| **MinimalLambda.Envelopes.Kinesis**                  | Data Streams with typed records                       | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Kinesis.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kinesis)                 | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Kinesis.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kinesis/)                 |
+| Package                                     | Description                                           | NuGet                                                                                                                                                          | Downloads                                                                                                                                                            |
+|---------------------------------------------|-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **MinimalLambda.Envelopes**                 | Infrastructure package for HTTP response builders     | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes)                                 | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes/)                                 |
+| **MinimalLambda.Envelopes.Sqs**             | Simple Queue Service events with typed message bodies | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Sqs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sqs)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Sqs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sqs/)                         |
+| **MinimalLambda.Envelopes.Sns**             | Simple Notification Service messages                  | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Sns.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sns)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Sns.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sns/)                         |
+| **MinimalLambda.Envelopes.ApiGateway**      | REST, HTTP, and WebSocket APIs                        | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.ApiGateway.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.ApiGateway)           | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.ApiGateway.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.ApiGateway/)           |
+| **MinimalLambda.Envelopes.Kinesis**         | Data Streams with typed records                       | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Kinesis.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kinesis)                 | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Kinesis.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kinesis/)                 |
 | **MinimalLambda.Envelopes.KinesisFirehose** | Data transformation                                   | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.KinesisFirehose.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.KinesisFirehose) | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.KinesisFirehose.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.KinesisFirehose/) |
-| **MinimalLambda.Envelopes.Kafka**                      | MSK and self-managed Kafka                            | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Kafka.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kafka)                     | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Kafka.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kafka/)                     |
-| **MinimalLambda.Envelopes.CloudWatchLogs**   | Log subscriptions                                     | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.CloudWatchLogs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.CloudWatchLogs)   | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.CloudWatchLogs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.CloudWatchLogs/)   |
-| **MinimalLambda.Envelopes.Alb**                          | Application Load Balancer requests                    | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Alb.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Alb)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Alb.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Alb/)                         |
+| **MinimalLambda.Envelopes.Kafka**           | MSK and self-managed Kafka                            | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Kafka.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kafka)                     | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Kafka.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kafka/)                     |
+| **MinimalLambda.Envelopes.CloudWatchLogs**  | Log subscriptions                                     | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.CloudWatchLogs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.CloudWatchLogs)   | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.CloudWatchLogs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.CloudWatchLogs/)   |
+| **MinimalLambda.Envelopes.Alb**             | Application Load Balancer requests                    | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Alb.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Alb)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Alb.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Alb/)                         |
 
 [Browse all envelope packages](features/envelopes.md){ .md-button }
 
@@ -222,7 +227,8 @@ deserialization.
 
 ## Examples & Use Cases
 
-Explore the repository’s `examples/` folder and the docs’ [Examples](examples/index.md) page (content coming
+Explore the repository’s `examples/` folder and the docs’ [Examples](examples/index.md) page (
+content coming
 soon) for end-to-end Lambda samples that wire up middleware, envelopes, and DI.
 
 [Examples (Coming Soon)](examples/index.md){ .md-button }
@@ -233,22 +239,27 @@ soon) for end-to-end Lambda samples that wire up middleware, envelopes, and DI.
 
 ### Get Involved
 
-- **[GitHub Repository](https://github.com/j-d-ha/minimal-lambda)** – Source code, issues, and discussions.
+- **[GitHub Repository](https://github.com/j-d-ha/minimal-lambda)** – Source code, issues, and
+  discussions.
 - **[Changelog](changelog.md)** – Version history and release notes.
 - **[License](https://github.com/j-d-ha/minimal-lambda/blob/main/LICENSE)** – MIT License.
 
 ### Documentation
 
 - **[Getting Started](getting-started/index.md)** – Installation and first Lambda tutorial.
-- **[Guides](guides/index.md)** – In-depth docs on DI, middleware, lifecycle, configuration, and more.
+- **[Guides](guides/index.md)** – In-depth docs on DI, middleware, lifecycle, configuration, and
+  more.
 - **[Features](features/index.md)** – Envelopes, OpenTelemetry integration, and other add-ons.
-- **[Advanced Topics](advanced/index.md)** – Coming soon: AOT, source generators, performance tuning.
+- **[Advanced Topics](advanced/index.md)** – Coming soon: AOT, source generators, performance
+  tuning.
 
 ### Support
 
 - Ask or search in [GitHub Discussions](https://github.com/j-d-ha/minimal-lambda/discussions).
-- File bugs or feature requests via [GitHub Issues](https://github.com/j-d-ha/minimal-lambda/issues).
+- File bugs or feature requests
+  via [GitHub Issues](https://github.com/j-d-ha/minimal-lambda/issues).
 
 ---
 
-**Ready to modernize your Lambda development?** [Get started now](getting-started/index.md){ .md-button .md-button--primary }
+**Ready to modernize your Lambda development?** [Get started now](getting-started/index.md){
+.md-button .md-button--primary }


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

Removes SonarQube/SonarCloud integration from CI workflows and all references in documentation. The `.venv` gitignore entry is also included as a minor cleanup.

---

## 🔄 Changes

- Remove SonarQube steps from `main-build.yaml` and `pr-build.yaml`
- Update `CONTRIBUTING.md` and `docs/index.md` to remove SonarCloud references
- Remove SonarCloud badge from `README.md`
- Add `.venv` to `.gitignore`

---

## ✅ Checklist

- [x] My changes build cleanly
- [x] I've added/updated relevant tests
- [x] I've added/updated documentation or README
- [x] I've followed the coding style for this project
- [x] I've tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

Closes #...

---

## 💬 Notes for Reviewers

Pure removal — no logic changes. Safe to merge once CI passes.