### PR TITLE
docs: migrate documentation to Zensical

### DIFF
--- a/.agents/skills/zensical-site/SKILL.md
+++ b/.agents/skills/zensical-site/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: zensical-site
+description: Use this skill whenever the user asks for anything related to https://zensical.org/ including researching pages, drafting or editing site copy, planning information architecture, writing Zensical-style markdown, extracting key points from docs, or preparing publish-ready content updates. Trigger even if the user does not explicitly mention "skill" or "zensical-style" but the work is clearly about zensical.org content.
+---
+
+# Zensical Site Assistant
+
+Use this skill to create, revise, and organize content for [zensical.org](https://zensical.org/).
+
+This skill is intentionally lightweight: use compact reference pages for output-critical rules, and
+link out to upstream docs for deep detail.
+
+## When to use this skill
+
+Use this skill if the user asks to:
+
+- Draft new pages/posts for zensical.org.
+- Rewrite existing copy for clarity, tone, or SEO.
+- Build content outlines, page briefs, or navigation structure.
+- Summarize or compare pages from zensical.org.
+- Convert rough notes into Zensical-style markdown.
+
+## Core workflow
+
+1. Clarify the content objective (page type, audience, and intent).
+2. Collect source material from zensical.org and any user-provided notes.
+3. Open [Authoring Reference Index](references/authoring-reference-index.md) and load only the
+   subject references needed for this task.
+4. Draft using the output template in this skill.
+5. Run a quality pass for tone, structure, links, front matter, and factual consistency.
+6. Return final markdown plus a short rationale and suggested next edits.
+
+## Output format
+
+Always provide:
+
+1. `Draft` (markdown ready to paste into the site)
+2. `Rationale` (2-5 bullets explaining important choices)
+3. `Open Questions` (only when missing info blocks quality)
+
+Use the page template in [Page Draft Template](templates/page-draft-template.md) unless the user
+requests another format.
+
+## Writing guidance
+
+- Prefer plain language and concrete examples.
+- Keep paragraphs short and scannable.
+- Use descriptive headings.
+- Avoid hype and vague claims.
+- Include links with meaningful anchor text.
+
+## Reference routing
+
+Start with:
+
+- [Authoring Reference Index](references/authoring-reference-index.md)
+
+Then load only what is needed:
+
+- [Markdown and Links](references/core/markdown-and-links.md) for links, heading structure, and
+  title behavior.
+- [Front Matter](references/core/front-matter.md) for page metadata.
+- [Callouts and Interactive Elements](references/subjects/callouts-and-interactive-elements.md) for
+  admonitions, buttons, tabs, and tooltips.
+- [Code and Technical Content](references/subjects/code-and-technical-content.md) for code blocks,
+  diagrams, and math.
+- [Layout and Media](references/subjects/layout-and-media.md) for grids, images, and icons/emojis.
+- [Data and Visualization](references/subjects/data-and-visualization.md) for tables and structured
+  visual content patterns.
+- [Inline Formatting and Microcontent](references/subjects/inline-formatting-and-microcontent.md)
+  for lists, inline formatting, and footnotes.
+
+If output depends on setup/runtime behavior, feature flags, or config snippets, load:
+
+- [Configuration Reference](references/dependencies/configuration-reference.md)
+- [Extension Prerequisites](references/dependencies/extension-prereqs.md)
+- [Navigation and Runtime Caveats](references/dependencies/navigation-runtime-caveats.md)
+- [Customization Boundaries](references/dependencies/customization-boundaries.md)
+
+Use [Shared Patterns](references/shared-patterns.md) for common rules and shared conventions.
+
+## Sources and verification
+
+- If browsing is available, reference exact pages used.
+- Flag uncertainty instead of guessing.
+- Do not invent product features, policies, or URLs.
+- If deeper implementation detail is needed, cite the relevant upstream Zensical doc rather than
+  expanding these references inline.

--- a/.agents/skills/zensical-site/references/authoring-reference-index.md
+++ b/.agents/skills/zensical-site/references/authoring-reference-index.md
@@ -1,0 +1,36 @@
+# Authoring Reference Index
+
+Use this page to decide which reference file to load for a task.
+
+## How to use this index
+
+1. Identify the user task type.
+2. Load the matching core or subject reference.
+3. Load dependency references whenever output depends on setup, feature flags, runtime behavior, or
+   TOML snippets.
+4. If the user asks for advanced behavior, link out to upstream docs.
+
+## Task routing
+
+| User need                                             | Open this reference first                                                            | Also check                                                                                                                                                                                                     |
+|-------------------------------------------------------|--------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Write or rewrite a standard docs page                 | [Markdown and Links](core/markdown-and-links.md)                                     | [Shared Patterns](shared-patterns.md), [Front Matter](core/front-matter.md)                                                                                                                                    |
+| Set page metadata                                     | [Front Matter](core/front-matter.md)                                                 | [Configuration Reference](dependencies/configuration-reference.md), [Navigation and Runtime Caveats](dependencies/navigation-runtime-caveats.md)                                                               |
+| Explain or draft `zensical.toml` configuration        | [Configuration Reference](dependencies/configuration-reference.md)                   | [Navigation and Runtime Caveats](dependencies/navigation-runtime-caveats.md), [Customization Boundaries](dependencies/customization-boundaries.md)                                                             |
+| Use admonitions, tabs, buttons, or tooltips           | [Callouts and Interactive Elements](subjects/callouts-and-interactive-elements.md)   | [Extension Prerequisites](dependencies/extension-prereqs.md), [Configuration Reference](dependencies/configuration-reference.md)                                                                               |
+| Add code snippets, diagrams, or equations             | [Code and Technical Content](subjects/code-and-technical-content.md)                 | [Extension Prerequisites](dependencies/extension-prereqs.md), [Configuration Reference](dependencies/configuration-reference.md), [Navigation and Runtime Caveats](dependencies/navigation-runtime-caveats.md) |
+| Build media-rich layouts                              | [Layout and Media](subjects/layout-and-media.md)                                     | [Customization Boundaries](dependencies/customization-boundaries.md)                                                                                                                                           |
+| Create tables and structured data sections            | [Data and Visualization](subjects/data-and-visualization.md)                         | [Extension Prerequisites](dependencies/extension-prereqs.md), [Configuration Reference](dependencies/configuration-reference.md)                                                                               |
+| Improve text-level formatting and list structure      | [Inline Formatting and Microcontent](subjects/inline-formatting-and-microcontent.md) | [Shared Patterns](shared-patterns.md)                                                                                                                                                                          |
+| Figure out whether custom CSS/JS/templates are needed | [Customization Boundaries](dependencies/customization-boundaries.md)                 | [Docs Reference Outline](docs-reference-outline.md)                                                                                                                                                            |
+
+## When to escalate to upstream docs
+
+Escalate (link out) when the task asks for:
+
+- complex extension options not covered in these references
+- deep theme customization or override internals
+- unusual runtime behavior across multiple plugins
+- edge-case compatibility behavior that affects production output
+
+Use upstream links from [Docs Reference Outline](docs-reference-outline.md).

--- a/.agents/skills/zensical-site/references/content-types.md
+++ b/.agents/skills/zensical-site/references/content-types.md
@@ -1,0 +1,27 @@
+# Content Types (Scaffold)
+
+Define conventions by content type so outputs stay consistent.
+
+## Homepage sections
+
+- Goal: TODO
+- Typical structure: TODO
+- CTA style: TODO
+
+## Documentation pages
+
+- Goal: TODO
+- Typical structure: TODO
+- Link behavior: TODO
+
+## Blog or updates
+
+- Goal: TODO
+- Typical structure: TODO
+- Tone notes: TODO
+
+## Case studies (if applicable)
+
+- Goal: TODO
+- Typical structure: TODO
+- Evidence style: TODO

--- a/.agents/skills/zensical-site/references/core/front-matter.md
+++ b/.agents/skills/zensical-site/references/core/front-matter.md
@@ -1,0 +1,62 @@
+# Core: Front Matter
+
+Use this reference for page metadata and title/visibility controls.
+
+## Use this when
+
+- creating pages that need metadata
+- setting page title behavior explicitly
+- controlling discoverability or layout behavior per page
+
+## Minimum working pattern
+
+```markdown
+---
+title: Example Page
+description: One-sentence summary for readers.
+---
+
+# Example Page
+
+Page content starts here.
+```
+
+## Required config / prerequisites
+
+- Front matter support is expected in docs authoring flow.
+- Some keys influence behavior only when related setup features are enabled (search, navigation,
+  templates).
+- Use [Configuration Reference](../dependencies/configuration-reference.md) when status labels,
+  template overrides, or search behavior need matching `zensical.toml` setup.
+
+## What to capture in output
+
+- page identity: title/description
+- optional discoverability controls
+- optional layout controls when explicitly requested
+- metadata consistency with page body headings
+
+## Working rules
+
+- Keep front matter minimal; include only fields needed for the task.
+- Align metadata with page purpose and heading text.
+- If uncertain about advanced keys, call it out and provide a safe default.
+
+## Common mistakes to avoid
+
+- stuffing many optional keys without user need
+- title mismatch between front matter and body heading
+- using fields that depend on unknown site configuration without a caveat
+
+## Interactions / caveats
+
+- title precedence is affected by navigation and markdown
+  heading ([Markdown and Links](markdown-and-links.md)).
+- search/layout behavior can depend on setup
+  configuration ([Navigation and Runtime Caveats](../dependencies/navigation-runtime-caveats.md)).
+
+## Deeper docs
+
+- [Front matter](https://zensical.org/docs/authoring/frontmatter/)
+- [Search](https://zensical.org/docs/setup/search/)
+- [Navigation](https://zensical.org/docs/setup/navigation/)

--- a/.agents/skills/zensical-site/references/core/markdown-and-links.md
+++ b/.agents/skills/zensical-site/references/core/markdown-and-links.md
@@ -1,0 +1,60 @@
+# Core: Markdown and Links
+
+Use this reference for baseline page authoring, linking, and title behavior.
+
+## Use this when
+
+- drafting or rewriting standard docs pages
+- creating or updating internal links
+- deciding how titles should be derived
+
+## Minimum working pattern
+
+```markdown
+# Page Title
+
+Intro paragraph with context.
+
+## Section Heading
+
+Use relative links like [Front matter](../frontmatter/).
+```
+
+## Required config / prerequisites
+
+- No special extension needed for basic markdown.
+- Link output behavior depends on URL mode (`use_directory_urls`).
+
+## Key rules
+
+- Write links to docs pages using relative paths.
+- Do not hardcode output `.html` links for internal docs pages.
+- Keep one `#` heading per page body when title is content-driven.
+- If navigation/front matter sets title, ensure content heading stays consistent.
+
+## Page title precedence
+
+In practice, title resolution follows this order:
+
+1. navigation-defined title
+2. front matter title
+3. first-level markdown heading
+4. filename fallback
+
+## Common mistakes to avoid
+
+- linking to built HTML instead of docs-relative page paths
+- mixing absolute and relative links inconsistently
+- adding multiple top-level headings in one page
+- assuming content `#` always controls title when nav/front matter overrides it
+
+## Interactions / caveats
+
+- front matter can override visible title behavior ([Front Matter](front-matter.md)).
+- URL mode impacts generated
+  paths ([Navigation and Runtime Caveats](../dependencies/navigation-runtime-caveats.md)).
+
+## Deeper docs
+
+- [Markdown](https://zensical.org/docs/authoring/markdown/)
+- [Basics: use_directory_urls](https://zensical.org/docs/setup/basics/#use_directory_urls)

--- a/.agents/skills/zensical-site/references/dependencies/configuration-reference.md
+++ b/.agents/skills/zensical-site/references/dependencies/configuration-reference.md
@@ -1,0 +1,196 @@
+# Dependencies: Configuration Reference
+
+Use this page when the task depends on how Zensical is configured, not just on markdown syntax.
+
+## Default configuration model
+
+- Prefer `zensical.toml` examples and guidance.
+- Zensical can read `mkdocs.yml`, but this skill should default to TOML unless the user is
+  explicitly migrating or maintaining YAML.
+- Most settings live under `[project]`.
+- `site_name` is required in the project config.
+- Theme flags usually live under `[project.theme]`.
+- Markdown features usually live under `[project.markdown_extensions...]`.
+- Template and behavior overrides often use `[project.extra]`, `extra_css`, `extra_javascript`, and
+  `custom_dir`.
+
+## Core TOML patterns to recognize
+
+### Base project settings
+
+```toml
+[project]
+site_name = "Example Docs"
+site_url = "https://docs.example.com"
+docs_dir = "docs"
+site_dir = "site"
+use_directory_urls = true
+```
+
+### Theme features
+
+```toml
+[project.theme]
+features = ["navigation.instant", "search.highlight"]
+```
+
+### Navigation structure
+
+```toml
+[project]
+nav = [
+  { Home = "index.md" },
+  { Guides = [{ Getting_started = "guides/getting-started.md" }] }
+]
+```
+
+### Markdown extension blocks
+
+```toml
+[project.markdown_extensions.admonition]
+
+[project.markdown_extensions.pymdownx.details]
+
+[project.markdown_extensions.pymdownx.superfences]
+```
+
+### Asset registration
+
+```toml
+[project]
+extra_css = ["stylesheets/extra.css"]
+extra_javascript = ["javascripts/extra.js"]
+```
+
+### Structured JavaScript entries
+
+```toml
+[[project.extra_javascript]]
+path = "javascripts/extra.mjs"
+type = "module"
+```
+
+### Extra metadata for templates/features
+
+```toml
+[project.extra.status]
+new = "Recently added"
+deprecated = "Deprecated"
+```
+
+## Path and scope rules
+
+- `docs_dir` and `site_dir` are relative to the config file.
+- `docs_dir` cannot currently be `.`.
+- `extra_css` and `extra_javascript` paths point to files inside the docs directory.
+- `custom_dir` is resolved relative to the config file, not relative to `docs_dir`.
+- Use `document$.subscribe(...)` in custom JavaScript when behavior must survive instant navigation.
+
+## Feature-to-config map
+
+### Navigation and previews
+
+- `navigation.instant` requires `site_url` to be set.
+- Instant previews also require `site_url`.
+- Instant preview automation uses `[project.markdown_extensions.zensical.extensions.preview]` with
+  nested `configurations`.
+- `navigation.prune` is incompatible with `navigation.expand`.
+- `navigation.indexes` is incompatible with `toc.integrate`.
+
+### Front matter behaviors
+
+- Page status badges require `[project.extra.status]` before `status:` in front matter will mean
+  anything.
+- Page templates require `[project.theme] custom_dir = "overrides"` and a template file in that
+  overrides directory.
+- Search exclusion for an entire page works with front matter alone.
+- Search exclusion for sections or blocks requires `attr_list`.
+
+### Admonitions
+
+- Base admonitions need `[project.markdown_extensions.admonition]`.
+- Collapsible admonitions need `[project.markdown_extensions.pymdownx.details]`.
+- Nested admonitions or nested rich blocks need
+  `[project.markdown_extensions.pymdownx.superfences]`.
+- Admonition icon changes use `[project.theme.icon.admonition]`.
+
+### Buttons and attribute-driven styling
+
+- Buttons require `[project.markdown_extensions.attr_list]`.
+- Any advice that uses classes like `.md-button`, `.copy`, `.select`, or `data-search-exclude`
+  depends on `attr_list` support.
+
+### Content tabs
+
+- Content tabs need `[project.markdown_extensions.pymdownx.superfences]` and
+  `[project.markdown_extensions.pymdownx.tabbed]` with `alternate_style = true`.
+- Linked tabs across pages use `[project.theme] features = ["content.tabs.link"]`.
+- Better tab anchors can use `[project.markdown_extensions.pymdownx.tabbed.slugify]`.
+
+### Code blocks
+
+- Recommended code-block setup uses `pymdownx.highlight`, `pymdownx.inlinehilite`,
+  `pymdownx.snippets`, and `pymdownx.superfences`.
+- Good defaults for advanced code blocks include `anchor_linenums = true`, `line_spans = "__span"`,
+  and `pygments_lang_class = true`.
+- Global copy/select/annotate controls use theme features such as `content.code.copy`,
+  `content.code.select`, and `content.code.annotate`.
+- Code annotations depend on Pygments-based highlighting, not generic JavaScript highlighters.
+- Extra annotation selectors use `[project.extra.annotate]`.
+
+### Diagrams
+
+- Mermaid diagrams require `pymdownx.superfences` with a `custom_fences` entry for `mermaid`.
+- Standard Mermaid support needs no extra JavaScript beyond that fence config.
+- Advanced Mermaid customization can add `extra_javascript`, and any runtime code should work with
+  `document$.subscribe(...)` if needed.
+
+### Math
+
+- Math support needs `[project.markdown_extensions.pymdownx.arithmatex] generic = true`.
+- MathJax also needs `extra_javascript` entries for the local setup file and the MathJax CDN.
+- KaTeX also needs `extra_javascript`, `extra_css`, and a small runtime script.
+- Math runtime scripts should subscribe to `document$` so rendering works with instant navigation.
+
+### Tooltips and glossary patterns
+
+- Abbreviations need `[project.markdown_extensions.abbr]`.
+- Non-link tooltips and block-level tooltip attributes need `attr_list`.
+- Shared glossary snippets need `pymdownx.snippets`, often with `auto_append`.
+- Enhanced UI tooltips use the theme feature `content.tooltips`.
+
+### Tables
+
+- Basic table support uses `[project.markdown_extensions.tables]`.
+- Sortable tables are not built-in config flags; they require `extra_javascript` plus a runtime
+  helper script.
+
+## Safe authoring rules for this skill
+
+- When the user asks for config help, show TOML-first examples unless their repo already uses YAML.
+- Do not imply that a markdown feature works automatically if the docs say it needs extension or
+  theme setup.
+- When a feature works only with additional CSS, JS, icons, or overrides, separate the content draft
+  from the configuration snippet.
+- When a feature has compatibility caveats, mention them instead of presenting the setup as
+  universal.
+
+## Common gotchas
+
+- forgetting `[project]` or `[project.theme]` scopes in TOML examples
+- assuming `site_url` is optional for instant navigation or instant previews
+- using `status:` in front matter without defining statuses in `[project.extra.status]`
+- recommending `template:` without configuring `custom_dir`
+- suggesting section/block search exclusions without `attr_list`
+- combining `navigation.prune` with `navigation.expand`
+- combining `navigation.indexes` with `toc.integrate`
+- placing extra CSS/JS paths as if they were relative to the repo root instead of the docs directory
+
+## Deeper docs
+
+- [Basics](https://zensical.org/docs/setup/basics/)
+- [Navigation](https://zensical.org/docs/setup/navigation/)
+- [Search](https://zensical.org/docs/setup/search/)
+- [Python Markdown](https://zensical.org/docs/setup/extensions/python-markdown/)
+- [Python Markdown Extensions](https://zensical.org/docs/setup/extensions/python-markdown-extensions/)
+- [Customization](https://zensical.org/docs/customization/)

--- a/.agents/skills/zensical-site/references/dependencies/customization-boundaries.md
+++ b/.agents/skills/zensical-site/references/dependencies/customization-boundaries.md
@@ -1,0 +1,47 @@
+# Dependencies: Customization Boundaries
+
+Use this page to decide when markdown alone is enough and when customization work is required.
+
+## Use this when
+
+- the user asks for behavior that likely needs CSS, JS, templates, or overrides
+- visual requirements go beyond built-in authoring features
+- theme-level changes are requested
+
+## What markdown usually handles well
+
+- page structure and headings
+- links, lists, tables, code blocks, basic admonitions
+- standard media insertion
+
+## What often needs customization
+
+- custom component styling beyond built-in classes
+- bespoke interactive behavior
+- template-level layout changes
+- advanced theme overrides and block extensions
+
+## AI behavior rules
+
+- Do not fake custom behavior with invalid markdown syntax.
+- Clearly separate content draft from customization recommendations.
+- Provide a short "next implementation step" note when customization is required.
+
+## Escalation template
+
+When customization is needed, say:
+
+1. what part is achievable in markdown now
+2. what part requires customization
+3. which upstream section should be used next
+
+## Deeper docs
+
+- [Customization](https://zensical.org/docs/customization/)
+- [Customization: additional CSS](https://zensical.org/docs/customization/#additional-css)
+- [Customization: additional JavaScript](https://zensical.org/docs/customization/#additional-javascript)
+- [Customization: custom templates](https://zensical.org/docs/customization/#custom-templates)
+- [Customization: configuring overrides](https://zensical.org/docs/customization/#configuring-overrides)
+- [Customization: template overrides](https://zensical.org/docs/customization/#template-overrides)
+- [Customization: overriding blocks](https://zensical.org/docs/customization/#overriding-blocks)
+- [Customization: extending the theme](https://zensical.org/docs/customization/#extending-the-theme)

--- a/.agents/skills/zensical-site/references/dependencies/extension-prereqs.md
+++ b/.agents/skills/zensical-site/references/dependencies/extension-prereqs.md
@@ -1,0 +1,39 @@
+# Dependencies: Extension Prerequisites
+
+Use this page to check feature prerequisites before generating advanced syntax.
+
+## Use this when
+
+- a subject feature might depend on markdown extensions
+- output behavior differs by installed extension stack
+- you need to decide between advanced syntax and safe fallback syntax
+
+## Feature-to-prerequisite map
+
+- Admonitions -> markdown extension support for admonition blocks
+- Buttons -> style/extension support for button classes
+- Content tabs -> extension support for tabbed content syntax
+- Advanced code block options -> code extension support
+- Diagrams -> Mermaid support
+- Math -> math renderer setup (MathJax or KaTeX path)
+- Tooltips/abbreviations -> extension support
+- Grids/cards/icons extras -> extension and/or theme support
+
+## Safe default policy
+
+- If prerequisite status is unknown, use a simpler markdown pattern.
+- Add an `Open Questions` note when setup is required for the requested output.
+- Use [Configuration Reference](configuration-reference.md) when the user needs actual
+  `zensical.toml` snippets.
+- Do not invent extension names or settings.
+
+## Verification checklist
+
+- Is this feature in a dependency-heavy subject area?
+- Is there a known extension requirement?
+- Can a simpler equivalent communicate the same content?
+
+## Deeper docs
+
+- [Python Markdown](https://zensical.org/docs/setup/extensions/python-markdown/)
+- [Python Markdown Extensions](https://zensical.org/docs/setup/extensions/python-markdown-extensions/)

--- a/.agents/skills/zensical-site/references/dependencies/navigation-runtime-caveats.md
+++ b/.agents/skills/zensical-site/references/dependencies/navigation-runtime-caveats.md
@@ -1,0 +1,34 @@
+# Dependencies: Navigation and Runtime Caveats
+
+Use this page when rendering behavior may change due to navigation/runtime configuration.
+
+## Use this when
+
+- output includes JS-backed features (tabs, diagrams, math, sortable tables)
+- behavior differs between first load and in-site navigation
+- page metadata interacts with layout/navigation controls
+
+## Key caveats to remember
+
+- Instant navigation can change how some client-side features initialize.
+- Sidebar and navigation settings can influence layout expectations.
+- URL mode changes internal link output behavior.
+
+## Authoring implications
+
+- Keep link syntax compatible with docs-relative navigation.
+- Avoid relying on fragile runtime-only behavior unless confirmed.
+- Mention caveats when the user asks for advanced interactive behavior.
+- If the user needs the exact TOML flags involved, pair this page
+  with [Configuration Reference](configuration-reference.md).
+
+## Fallback policy
+
+- Prefer stable, static markdown patterns when runtime behavior is uncertain.
+- If interactive behavior is required, call out dependency assumptions clearly.
+
+## Deeper docs
+
+- [Navigation: instant navigation](https://zensical.org/docs/setup/navigation/#instant-navigation)
+- [Navigation: hide the sidebars](https://zensical.org/docs/setup/navigation/#hide-the-sidebars)
+- [Basics: use_directory_urls](https://zensical.org/docs/setup/basics/#use_directory_urls)

--- a/.agents/skills/zensical-site/references/docs-reference-outline.md
+++ b/.agents/skills/zensical-site/references/docs-reference-outline.md
@@ -1,0 +1,93 @@
+# Zensical Docs Reference Outline
+
+Goal: define which docs to reference later when expanding the `zensical-site` skill, and what to
+extract from each.
+
+## 1) Authoring docs to reference
+
+- [Markdown](https://zensical.org/docs/authoring/markdown/)
+  - Pull later: baseline markdown rules, internal linking guidance, page-title precedence.
+- [Front matter](https://zensical.org/docs/authoring/frontmatter/)
+  - Pull later: supported front matter keys, precedence/override behavior, layout/search-related
+    keys.
+- [Admonitions](https://zensical.org/docs/authoring/admonitions/)
+  - Pull later: syntax variants, supported admonition types, required extension/config.
+- [Buttons](https://zensical.org/docs/authoring/buttons/)
+  - Pull later: button syntax/classes, icon usage in buttons, extension requirements.
+- [Code blocks](https://zensical.org/docs/authoring/code-blocks/)
+  - Pull later: fenced code options (titles/line numbers/highlights/annotations/snippets), toggles,
+    feature flags.
+- [Content tabs](https://zensical.org/docs/authoring/content-tabs/)
+  - Pull later: tab syntax, linked-tab behavior, nesting/anchor constraints.
+- [Data tables](https://zensical.org/docs/authoring/data-tables/)
+  - Pull later: table syntax conventions, sorting integration, compatibility constraints.
+- [Diagrams](https://zensical.org/docs/authoring/diagrams/)
+  - Pull later: Mermaid setup, supported diagram families, customization hooks.
+- [Footnotes](https://zensical.org/docs/authoring/footnotes/)
+  - Pull later: reference/definition syntax, tooltip integration behavior.
+- [Formatting](https://zensical.org/docs/authoring/formatting/)
+  - Pull later: inline formatting patterns, required extensions.
+- [Grids](https://zensical.org/docs/authoring/grids/)
+  - Pull later: card/grid container syntax, nesting rules, extension dependencies.
+- [Icons, Emojis](https://zensical.org/docs/authoring/icons-emojis/)
+  - Pull later: shortcode conventions, icon naming rules, template usage.
+- [Images](https://zensical.org/docs/authoring/images/)
+  - Pull later: alignment/captions/lazy-load patterns, light/dark asset behavior.
+- [Lists](https://zensical.org/docs/authoring/lists/)
+  - Pull later: list-type syntax (unordered/ordered/definition/task), extension requirements.
+- [Math](https://zensical.org/docs/authoring/math/)
+  - Pull later: MathJax vs KaTeX options, delimiter conventions, navigation integration caveats.
+- [Tooltips](https://zensical.org/docs/authoring/tooltips/)
+  - Pull later: tooltip and abbreviation syntax, glossary automation behavior.
+
+## 2) Cross-reference docs required for authoring correctness
+
+- [Basics: use_directory_urls](https://zensical.org/docs/setup/basics/#use_directory_urls)
+  - Pull later: how URL mode changes link generation/resolution.
+- [Navigation: instant navigation](https://zensical.org/docs/setup/navigation/#instant-navigation)
+  - Pull later: runtime navigation behavior impacting JS-backed features (math/diagrams/tables).
+- [Navigation: hide the sidebars](https://zensical.org/docs/setup/navigation/#hide-the-sidebars)
+  - Pull later: sidebar/layout controls that affect page composition and front matter.
+- [Site search](https://zensical.org/docs/setup/search/)
+  - Pull later: metadata/indexing behavior tied to front matter and discoverability.
+- [Colors](https://zensical.org/docs/setup/colors/)
+  - Pull later: theme/palette behavior affecting rendering choices.
+- [Logo and icons: additional icons](https://zensical.org/docs/setup/logo-and-icons/#additional-icons)
+  - Pull later: custom icon registration and usage flow.
+- [Python Markdown](https://zensical.org/docs/setup/extensions/python-markdown/)
+  - Pull later: base Python Markdown extension setup required by authoring features.
+- [Python Markdown Extensions](https://zensical.org/docs/setup/extensions/python-markdown-extensions/)
+  - Pull later: pymdown extension setup/options used across many authoring features.
+- [Customization](https://zensical.org/docs/customization/)
+  - Pull later: CSS/JS/template override mechanisms for behavior and styling adjustments.
+- [Customization: additional CSS](https://zensical.org/docs/customization/#additional-css)
+  - Pull later: custom stylesheet integration points.
+- [Customization: additional JavaScript](https://zensical.org/docs/customization/#additional-javascript)
+  - Pull later: custom JS integration points.
+- [Customization: custom templates](https://zensical.org/docs/customization/#custom-templates)
+  - Pull later: template customization entry points.
+- [Customization: configuring overrides](https://zensical.org/docs/customization/#configuring-overrides)
+  - Pull later: override config structure and placement.
+- [Customization: template overrides](https://zensical.org/docs/customization/#template-overrides)
+  - Pull later: template override behavior and scope.
+- [Customization: overriding blocks](https://zensical.org/docs/customization/#overriding-blocks)
+  - Pull later: block-level extension points.
+- [Customization: extending the theme](https://zensical.org/docs/customization/#extending-the-theme)
+  - Pull later: theme extension strategy and boundaries.
+
+## 3) Extraction template for the next pass
+
+Use these fields when we return to pull details:
+
+- `doc_url`
+- `doc_title`
+- `feature_area`
+- `authoring_purpose`
+- `required_config`
+- `syntax_patterns`
+- `options_modifiers`
+- `dependencies`
+- `behavioral_rules`
+- `limitations_edge_cases`
+- `cross_reference_urls`
+- `minimal_examples_to_capture`

--- a/.agents/skills/zensical-site/references/shared-patterns.md
+++ b/.agents/skills/zensical-site/references/shared-patterns.md
@@ -1,0 +1,40 @@
+# Shared Patterns
+
+Use this page for rules that apply across multiple subject references.
+
+## Link handling
+
+- Use relative links for internal docs navigation.
+- Link to markdown sources/pages, not built HTML artifacts.
+- Use meaningful anchor text.
+- Avoid absolute links unless the destination is external.
+
+## Title and structure defaults
+
+- Use one top-level heading per page.
+- Keep heading hierarchy consistent (`#`, `##`, `###`).
+- Keep paragraphs short and scannable.
+
+## Minimal example standard
+
+For each feature example:
+
+- show the smallest valid syntax pattern
+- include only one meaningful option at a time
+- avoid stacking unrelated options in one block
+
+## Failure prevention checklist
+
+Before final output, quickly check:
+
+- internal links are relative and valid for docs context
+- front matter and body title do not conflict
+- feature syntax matches the relevant subject reference
+- required prerequisites are called out when needed
+- unresolved assumptions are listed in `Open Questions`
+
+## Escalation rule
+
+When deeper behavior is needed, do not guess.
+Link to the corresponding upstream docs listed
+in [Docs Reference Outline](docs-reference-outline.md).

--- a/.agents/skills/zensical-site/references/subjects/callouts-and-interactive-elements.md
+++ b/.agents/skills/zensical-site/references/subjects/callouts-and-interactive-elements.md
@@ -1,0 +1,77 @@
+# Subject: Callouts and Interactive Elements
+
+Includes admonitions, buttons, content tabs, and tooltips.
+
+## Use this when
+
+- emphasizing important notes/warnings
+- creating action-style links with button presentation
+- organizing alternative content paths with tabs
+- adding inline clarifications with tooltips/abbreviations
+
+## Minimum working patterns
+
+### Admonition
+
+```markdown
+!!! note
+    Key context for the reader.
+```
+
+### Button-style link
+
+```markdown
+[Get Started](../get-started/){ .md-button }
+```
+
+### Content tab
+
+```markdown
+=== "CLI"
+    Use this command.
+
+=== "UI"
+    Use this interface path.
+```
+
+### Tooltip/abbreviation
+
+```markdown
+The API uses HTML.
+
+*[HTML]: HyperText Markup Language
+```
+
+## Required config / prerequisites
+
+- Most patterns depend on specific markdown extensions.
+- Verify extension availability in [Extension Prerequisites](../dependencies/extension-prereqs.md)
+  when behavior is uncertain.
+- Use [Configuration Reference](../dependencies/configuration-reference.md) when the answer should
+  include TOML examples for tabs, admonitions, buttons, tooltips, or linked tabs.
+
+## Common options the model may need
+
+- admonition type (`note`, `warning`, `tip`, etc.)
+- button styling classes (if supported)
+- tab labels that map to reader context (for example, platform names)
+
+## Common mistakes to avoid
+
+- incorrect indentation inside admonitions or tab bodies
+- mixing tab syntaxes in one block
+- using button classes without ensuring style support
+- turning critical instructions into tooltips that hide required info
+
+## Interactions / caveats
+
+- Tabs and tooltips may rely on extension support and theme behavior.
+- If interaction behavior is runtime-sensitive,
+  check [Navigation and Runtime Caveats](../dependencies/navigation-runtime-caveats.md).
+
+## Deeper docs
+
+- [Admonitions](https://zensical.org/docs/authoring/admonitions/)
+- [Buttons](https://zensical.org/docs/authoring/buttons/)
+- [Content tabs](https://zensical.org/docs/authoring/content-tabs/)
+- [Tooltips](https://zensical.org/docs/authoring/tooltips/)

--- a/.agents/skills/zensical-site/references/subjects/code-and-technical-content.md
+++ b/.agents/skills/zensical-site/references/subjects/code-and-technical-content.md
@@ -1,0 +1,74 @@
+# Subject: Code and Technical Content
+
+Includes code blocks, diagrams, and math.
+
+## Use this when
+
+- showing commands or source code
+- adding architecture or flow diagrams
+- writing equations or math-heavy technical docs
+
+## Minimum working patterns
+
+### Code block
+
+````markdown
+```bash
+zensical build
+```
+````
+
+### Mermaid diagram
+
+````markdown
+```mermaid
+graph TD
+  A[Start] --> B[Build]
+```
+````
+
+### Math
+
+```markdown
+Inline: $E=mc^2$
+
+Block:
+$$
+\int_0^1 x^2 dx
+$$
+```
+
+## Required config / prerequisites
+
+- syntax highlighting and advanced code features depend on markdown extensions
+- diagrams require Mermaid support
+- math rendering requires configured math engine (MathJax/KaTeX path)
+- use [Configuration Reference](../dependencies/configuration-reference.md) when the user needs
+  actual TOML, `extra_javascript`, or `extra_css` examples
+
+Use [Extension Prerequisites](../dependencies/extension-prereqs.md) for prerequisite mapping.
+
+## Common options the model may need
+
+- code title/line number/highlight options
+- diagram type selection by intent (flow, sequence, state)
+- inline vs block math choice
+
+## Common mistakes to avoid
+
+- malformed fence syntax or missing language labels
+- using advanced code options without checking support
+- combining unsupported Mermaid constructs blindly
+- adding math delimiters incompatible with configured renderer
+
+## Interactions / caveats
+
+- client-side navigation may require runtime-safe behavior for diagrams/math rendering.
+- if runtime behavior is uncertain,
+  check [Navigation and Runtime Caveats](../dependencies/navigation-runtime-caveats.md).
+
+## Deeper docs
+
+- [Code blocks](https://zensical.org/docs/authoring/code-blocks/)
+- [Diagrams](https://zensical.org/docs/authoring/diagrams/)
+- [Math](https://zensical.org/docs/authoring/math/)

--- a/.agents/skills/zensical-site/references/subjects/data-and-visualization.md
+++ b/.agents/skills/zensical-site/references/subjects/data-and-visualization.md
@@ -1,0 +1,52 @@
+# Subject: Data and Visualization
+
+Includes data tables and structured visual data presentation.
+
+## Use this when
+
+- presenting comparable values in table form
+- creating compact structured summaries
+- adding sortable or interactive table patterns when supported
+
+## Minimum working pattern
+
+```markdown
+| Metric | Value |
+| --- | --- |
+| Build time | 42s |
+| Pages | 120 |
+```
+
+## Required config / prerequisites
+
+- basic tables work in markdown
+- sortable/interactive behavior may require extra setup
+- use [Configuration Reference](../dependencies/configuration-reference.md) when the answer needs
+  `extra_javascript` examples or search-related caveats
+
+Check [Extension Prerequisites](../dependencies/extension-prereqs.md)
+and [Navigation and Runtime Caveats](../dependencies/navigation-runtime-caveats.md) for
+setup-sensitive behavior.
+
+## Common options the model may need
+
+- alignment and readability choices
+- compact column labels for small screens
+- simple grouping by section before large tables
+
+## Common mistakes to avoid
+
+- very wide tables without considering readability
+- dense numeric tables without context labels
+- assuming sorting is available without support confirmation
+
+## Interactions / caveats
+
+- large tables often need surrounding explanation text.
+- for complex visualizations, use diagrams guidance
+  in [Code and Technical Content](code-and-technical-content.md).
+
+## Deeper docs
+
+- [Data tables](https://zensical.org/docs/authoring/data-tables/)
+- [Diagrams](https://zensical.org/docs/authoring/diagrams/)

--- a/.agents/skills/zensical-site/references/subjects/inline-formatting-and-microcontent.md
+++ b/.agents/skills/zensical-site/references/subjects/inline-formatting-and-microcontent.md
@@ -1,0 +1,64 @@
+# Subject: Inline Formatting and Microcontent
+
+Includes formatting, lists, and footnotes.
+
+## Use this when
+
+- improving readability of technical prose
+- structuring procedures, requirements, and definitions
+- adding supporting references that should not interrupt flow
+
+## Minimum working patterns
+
+### Lists
+
+```markdown
+- First item
+- Second item
+
+1. Step one
+2. Step two
+```
+
+### Inline emphasis
+
+```markdown
+Use **bold** for emphasis and `inline code` for commands.
+```
+
+### Footnote
+
+```markdown
+The behavior depends on configuration.[^1]
+
+[^1]: Verify setup before publishing.
+```
+
+## Required config / prerequisites
+
+- basic lists and emphasis are markdown-native
+- some advanced formatting or footnote rendering can depend on extension support
+
+## Common options the model may need
+
+- ordered vs unordered lists by intent
+- definition/task list patterns when supported
+- restrained inline emphasis for scanability
+
+## Common mistakes to avoid
+
+- over-formatting simple prose
+- mixing list indentation levels incorrectly
+- using footnotes for critical instructions that should stay inline
+- inconsistent list punctuation/voice within one section
+
+## Interactions / caveats
+
+- footnotes and advanced list behavior may vary by extension setup.
+- if behavior is unclear, use simpler markdown and add a note.
+
+## Deeper docs
+
+- [Formatting](https://zensical.org/docs/authoring/formatting/)
+- [Lists](https://zensical.org/docs/authoring/lists/)
+- [Footnotes](https://zensical.org/docs/authoring/footnotes/)

--- a/.agents/skills/zensical-site/references/subjects/layout-and-media.md
+++ b/.agents/skills/zensical-site/references/subjects/layout-and-media.md
@@ -1,0 +1,59 @@
+# Subject: Layout and Media
+
+Includes grids, images, and icons/emojis.
+
+## Use this when
+
+- building card layouts or visual content blocks
+- adding screenshots, diagrams, or illustrative assets
+- using iconography to improve scanability
+
+## Minimum working patterns
+
+### Image
+
+```markdown
+![Setup screen](../assets/setup-screen.png)
+```
+
+### Grid/card block
+
+Use the simplest supported grid/card pattern from upstream docs for the current setup.
+
+### Icon/emoji
+
+Use supported shortcode or icon notation from the active icon set.
+
+## Required config / prerequisites
+
+- grid and icon behavior can depend on extension support
+- some icon sets require explicit setup
+- light/dark image swaps may rely on theme conventions
+
+See [Extension Prerequisites](../dependencies/extension-prereqs.md)
+and [Customization Boundaries](../dependencies/customization-boundaries.md).
+
+## Common options the model may need
+
+- image caption/alignment/lazy-load behavior
+- card layout variants with simple consistent structure
+- icon naming conventions for available packs
+
+## Common mistakes to avoid
+
+- large unoptimized images without context
+- relying on icons not registered in the site setup
+- using complex grid syntax when plain sections would communicate better
+- mixing visual patterns that reduce readability on small screens
+
+## Interactions / caveats
+
+- palette/theme choices can affect icon and image visibility.
+- if task requires custom styling tweaks, escalate to customization boundaries.
+
+## Deeper docs
+
+- [Grids](https://zensical.org/docs/authoring/grids/)
+- [Images](https://zensical.org/docs/authoring/images/)
+- [Icons and emojis](https://zensical.org/docs/authoring/icons-emojis/)
+- [Logo and icons: additional icons](https://zensical.org/docs/setup/logo-and-icons/#additional-icons)

--- a/.agents/skills/zensical-site/references/voice-and-tone.md
+++ b/.agents/skills/zensical-site/references/voice-and-tone.md
@@ -1,0 +1,19 @@
+# Voice and Tone (Scaffold)
+
+Use this file to capture concrete writing patterns from zensical.org.
+
+## Brand voice notes
+
+- TODO: Add 5-10 short excerpts from published pages.
+- TODO: Note preferred level of formality.
+- TODO: Note typical sentence length and pacing.
+
+## Do/Don't examples
+
+- Do: TODO
+- Don't: TODO
+
+## Terminology
+
+- Preferred terms: TODO
+- Terms to avoid: TODO

--- a/.agents/skills/zensical-site/templates/page-draft-template.md
+++ b/.agents/skills/zensical-site/templates/page-draft-template.md
@@ -1,0 +1,23 @@
+# {{ Page Title }}
+
+## Summary
+
+{{ 1-2 sentence summary of the page goal }}
+
+## Who this is for
+
+{{ target audience }}
+
+## Main content
+
+{{ organized sections with descriptive headings }}
+
+## Key takeaways
+
+- {{ takeaway 1 }}
+- {{ takeaway 2 }}
+- {{ takeaway 3 }}
+
+## Related links
+
+- \[{{ link text }}\]({{ url }})

--- a/.claude/skills/zensical-site
+++ b/.claude/skills/zensical-site
@@ -1,0 +1,1 @@
+../../.agents/skills/zensical-site

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -38,14 +38,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-
-      - name: Install pngquant
-        run: sudo apt-get update && sudo apt-get install -y pngquant
-
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version-file: "pyproject.toml"
+      
+      #      - name: Install pngquant
+      #        run: sudo apt-get update && sudo apt-get install -y pngquant
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -61,7 +56,7 @@ jobs:
 
       - name: Build documentation
         run: |
-          uv run mkdocs build --clean
+          uv run zensical build --clean
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -38,9 +38,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      
-      #      - name: Install pngquant
-      #        run: sudo apt-get update && sudo apt-get install -y pngquant
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Main Build](https://github.com/j-d-ha/minimal-lambda/actions/workflows/main-build.yaml/badge.svg)](https://github.com/j-d-ha/minimal-lambda/actions/workflows/main-build.yaml)
 [![codecov](https://codecov.io/gh/j-d-ha/minimal-lambda/graph/badge.svg?token=BWORPTQ0UK)](https://codecov.io/gh/j-d-ha/minimal-lambda)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=j-d-ha_minimal-lambda&metric=alert_status&token=9fb519975d91379dcfbc6c13a4bd4207131af6e3)](https://sonarcloud.io/summary/new_code?id=j-d-ha_minimal-lambda)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 **Lambda-first hosting with Minimal API-inspired patterns** – Familiar .NET ergonomics with

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,1 +1,0 @@
---8<-- "CHANGELOG.md"

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,16 @@ title: ""
 
 [![Main Build](https://github.com/j-d-ha/minimal-lambda/actions/workflows/main-build.yaml/badge.svg)](https://github.com/j-d-ha/minimal-lambda/actions/workflows/main-build.yaml)
 [![codecov](https://codecov.io/gh/j-d-ha/minimal-lambda/graph/badge.svg?token=BWORPTQ0UK)](https://codecov.io/gh/j-d-ha/minimal-lambda)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=j-d-ha_minimal-lambda&metric=alert_status&token=9fb519975d91379dcfbc6c13a4bd4207131af6e3)](https://sonarcloud.io/summary/new_code?id=j-d-ha_minimal-lambda)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/j-d-ha/minimal-lambda/blob/main/LICENSE)
 
 **Minimal API-inspired, Lambda-first hosting.**
 
-MinimalLambda keeps the builder, DI, middleware, and handler mapping patterns you know from ASP.NET Core, but is built from the ground up for **any Lambda event source** (SQS, SNS, API Gateway, Kinesis, S3, EventBridge, etc.). Strongly-typed envelopes, lifecycle hooks, scoped invocations, source generation, and cancellation-token handling shape those familiar patterns to Lambda’s execution model—so you get type-safe events, per-invocation scopes, predictable timeouts, and a smoother developer experience when iterating locally or in CI.
+MinimalLambda keeps the builder, DI, middleware, and handler mapping patterns you know from ASP.NET
+Core, but is built from the ground up for **any Lambda event source** (SQS, SNS, API Gateway,
+Kinesis, S3, EventBridge, etc.). Strongly-typed envelopes, lifecycle hooks, scoped invocations,
+source generation, and cancellation-token handling shape those familiar patterns to Lambda’s
+execution model—so you get type-safe events, per-invocation scopes, predictable timeouts, and a
+smoother developer experience when iterating locally or in CI.
 
 [Get Started](getting-started/index.md){ .md-button .md-button--primary }
 [Guides](guides/index.md){ .md-button }
@@ -21,7 +25,8 @@ MinimalLambda keeps the builder, DI, middleware, and handler mapping patterns yo
 
 ## Why MinimalLambda?
 
-Stop wiring up DI scopes, serializers, and cancellation tokens by hand. Ship features with patterns you
+Stop wiring up DI scopes, serializers, and cancellation tokens by hand. Ship features with patterns
+you
 already know, while still embracing Lambda’s execution model.
 
 === "Traditional Lambda"
@@ -174,8 +179,8 @@ await lambda.RunAsync();
 ```
 
 !!! tip "Next Steps"
-    Ready to dive deeper? Check out the [Getting Started Guide](getting-started/index.md) for a complete
-    tutorial, or explore the [Examples](examples/index.md) to see real-world applications.
+Ready to dive deeper? Check out the [Getting Started Guide](getting-started/index.md) for a complete
+tutorial, or explore the [Examples](examples/index.md) to see real-world applications.
 
 ---
 
@@ -186,11 +191,11 @@ await lambda.RunAsync();
 The core packages provide the fundamental hosting framework, abstractions, and observability support
 for building AWS Lambda functions.
 
-| Package                                                          | Description                                   | NuGet                                                                                                                                    | Downloads                                                                                                                                      |
-|------------------------------------------------------------------|-----------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| [**MinimalLambda**](https://github.com/j-d-ha/minimal-lambda/tree/main/src/MinimalLambda)                      | Core hosting framework with middleware and DI | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.svg)](https://www.nuget.org/packages/MinimalLambda)                             | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.svg)](https://www.nuget.org/packages/MinimalLambda/)                             |
+| Package                                                                                                             | Description                                   | NuGet                                                                                                                                  | Downloads                                                                                                                                    |
+|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| [**MinimalLambda**](https://github.com/j-d-ha/minimal-lambda/tree/main/src/MinimalLambda)                           | Core hosting framework with middleware and DI | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.svg)](https://www.nuget.org/packages/MinimalLambda)                             | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.svg)](https://www.nuget.org/packages/MinimalLambda/)                             |
 | [**MinimalLambda.Abstractions**](https://github.com/j-d-ha/minimal-lambda/tree/main/src/MinimalLambda.Abstractions) | Core interfaces and contracts                 | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Abstractions.svg)](https://www.nuget.org/packages/MinimalLambda.Abstractions)   | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Abstractions.svg)](https://www.nuget.org/packages/MinimalLambda.Abstractions/)   |
-| [**MinimalLambda.OpenTelemetry**](features/open_telemetry.md)    | Distributed tracing and observability         | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.OpenTelemetry.svg)](https://www.nuget.org/packages/MinimalLambda.OpenTelemetry) | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.OpenTelemetry.svg)](https://www.nuget.org/packages/MinimalLambda.OpenTelemetry/) |
+| [**MinimalLambda.OpenTelemetry**](features/open_telemetry.md)                                                       | Distributed tracing and observability         | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.OpenTelemetry.svg)](https://www.nuget.org/packages/MinimalLambda.OpenTelemetry) | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.OpenTelemetry.svg)](https://www.nuget.org/packages/MinimalLambda.OpenTelemetry/) |
 
 ### Envelope Packages
 
@@ -198,23 +203,23 @@ Envelope packages provide type-safe handling of AWS Lambda event sources with au
 deserialization.
 
 !!! info "What are Envelopes?"
-    Envelopes wrap AWS Lambda events with strongly-typed payload handling, giving you compile-time type
-    safety and automatic deserialization of message bodies from SQS, SNS, Kinesis, and other event
-    sources.
+Envelopes wrap AWS Lambda events with strongly-typed payload handling, giving you compile-time type
+safety and automatic deserialization of message bodies from SQS, SNS, Kinesis, and other event
+sources.
 
     [Learn more about envelopes](features/envelopes.md){ .md-button }
 
-| Package                                                                                | Description                                           | NuGet                                                                                                                                                            | Downloads                                                                                                                                                              |
-|----------------------------------------------------------------------------------------|-------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **MinimalLambda.Envelopes**                              | Infrastructure package for HTTP response builders     | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes)                                 | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes/)                                 |
-| **MinimalLambda.Envelopes.Sqs**                          | Simple Queue Service events with typed message bodies | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Sqs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sqs)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Sqs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sqs/)                         |
-| **MinimalLambda.Envelopes.Sns**                          | Simple Notification Service messages                  | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Sns.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sns)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Sns.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sns/)                         |
-| **MinimalLambda.Envelopes.ApiGateway**           | REST, HTTP, and WebSocket APIs                        | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.ApiGateway.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.ApiGateway)           | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.ApiGateway.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.ApiGateway/)           |
-| **MinimalLambda.Envelopes.Kinesis**                  | Data Streams with typed records                       | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Kinesis.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kinesis)                 | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Kinesis.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kinesis/)                 |
+| Package                                     | Description                                           | NuGet                                                                                                                                                          | Downloads                                                                                                                                                            |
+|---------------------------------------------|-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **MinimalLambda.Envelopes**                 | Infrastructure package for HTTP response builders     | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes)                                 | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes/)                                 |
+| **MinimalLambda.Envelopes.Sqs**             | Simple Queue Service events with typed message bodies | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Sqs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sqs)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Sqs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sqs/)                         |
+| **MinimalLambda.Envelopes.Sns**             | Simple Notification Service messages                  | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Sns.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sns)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Sns.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Sns/)                         |
+| **MinimalLambda.Envelopes.ApiGateway**      | REST, HTTP, and WebSocket APIs                        | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.ApiGateway.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.ApiGateway)           | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.ApiGateway.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.ApiGateway/)           |
+| **MinimalLambda.Envelopes.Kinesis**         | Data Streams with typed records                       | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Kinesis.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kinesis)                 | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Kinesis.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kinesis/)                 |
 | **MinimalLambda.Envelopes.KinesisFirehose** | Data transformation                                   | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.KinesisFirehose.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.KinesisFirehose) | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.KinesisFirehose.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.KinesisFirehose/) |
-| **MinimalLambda.Envelopes.Kafka**                      | MSK and self-managed Kafka                            | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Kafka.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kafka)                     | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Kafka.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kafka/)                     |
-| **MinimalLambda.Envelopes.CloudWatchLogs**   | Log subscriptions                                     | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.CloudWatchLogs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.CloudWatchLogs)   | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.CloudWatchLogs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.CloudWatchLogs/)   |
-| **MinimalLambda.Envelopes.Alb**                          | Application Load Balancer requests                    | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Alb.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Alb)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Alb.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Alb/)                         |
+| **MinimalLambda.Envelopes.Kafka**           | MSK and self-managed Kafka                            | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Kafka.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kafka)                     | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Kafka.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Kafka/)                     |
+| **MinimalLambda.Envelopes.CloudWatchLogs**  | Log subscriptions                                     | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.CloudWatchLogs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.CloudWatchLogs)   | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.CloudWatchLogs.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.CloudWatchLogs/)   |
+| **MinimalLambda.Envelopes.Alb**             | Application Load Balancer requests                    | [![NuGet](https://img.shields.io/nuget/v/MinimalLambda.Envelopes.Alb.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Alb)                         | [![Downloads](https://img.shields.io/nuget/dt/MinimalLambda.Envelopes.Alb.svg)](https://www.nuget.org/packages/MinimalLambda.Envelopes.Alb/)                         |
 
 [Browse all envelope packages](features/envelopes.md){ .md-button }
 
@@ -222,7 +227,8 @@ deserialization.
 
 ## Examples & Use Cases
 
-Explore the repository’s `examples/` folder and the docs’ [Examples](examples/index.md) page (content coming
+Explore the repository’s `examples/` folder and the docs’ [Examples](examples/index.md) page (
+content coming
 soon) for end-to-end Lambda samples that wire up middleware, envelopes, and DI.
 
 [Examples (Coming Soon)](examples/index.md){ .md-button }
@@ -233,22 +239,26 @@ soon) for end-to-end Lambda samples that wire up middleware, envelopes, and DI.
 
 ### Get Involved
 
-- **[GitHub Repository](https://github.com/j-d-ha/minimal-lambda)** – Source code, issues, and discussions.
-- **[Changelog](changelog.md)** – Version history and release notes.
+- **[GitHub Repository](https://github.com/j-d-ha/minimal-lambda)** – Source code, issues, and
+  discussions.
 - **[License](https://github.com/j-d-ha/minimal-lambda/blob/main/LICENSE)** – MIT License.
 
 ### Documentation
 
 - **[Getting Started](getting-started/index.md)** – Installation and first Lambda tutorial.
-- **[Guides](guides/index.md)** – In-depth docs on DI, middleware, lifecycle, configuration, and more.
+- **[Guides](guides/index.md)** – In-depth docs on DI, middleware, lifecycle, configuration, and
+  more.
 - **[Features](features/index.md)** – Envelopes, OpenTelemetry integration, and other add-ons.
-- **[Advanced Topics](advanced/index.md)** – Coming soon: AOT, source generators, performance tuning.
+- **[Advanced Topics](advanced/index.md)** – Coming soon: AOT, source generators, performance
+  tuning.
 
 ### Support
 
 - Ask or search in [GitHub Discussions](https://github.com/j-d-ha/minimal-lambda/discussions).
-- File bugs or feature requests via [GitHub Issues](https://github.com/j-d-ha/minimal-lambda/issues).
+- File bugs or feature requests
+  via [GitHub Issues](https://github.com/j-d-ha/minimal-lambda/issues).
 
 ---
 
-**Ready to modernize your Lambda development?** [Get started now](getting-started/index.md){ .md-button .md-button--primary }
+**Ready to modernize your Lambda development?** [Get started now](getting-started/index.md){
+.md-button .md-button--primary }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,6 @@ watch:
 nav:
   - Home:
       - index.md
-      - Changelog: changelog.md
   - Getting Started:
       - getting-started/index.md
       - Installation: getting-started/installation.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "minimal-lambda-docs"
 version = "0.1.0"
 description = "mkdocs for minimal-lambda"
 requires-python = ">=3.13"
-dependencies = [
-    "mkdocs>=1.6.1",
-    "mkdocs-material>=9.7.0",
+
+[dependency-groups]
+dev = [
+  "zensical>=0.0.33",
 ]

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,6 +5,11 @@
       "source": "LayeredCraft/skills",
       "sourceType": "github",
       "computedHash": "fbd78cda46da7d8753beca0d68ce6532589daa4da0a457aa709fe1e11da468fe"
+    },
+    "zensical-site": {
+      "source": "LayeredCraft/skills",
+      "sourceType": "github",
+      "computedHash": "f66b47704234c8242d45a52e3d92d5307f49254e189819165ee37845da64e9c8"
     }
   }
 }

--- a/tasks/LocalDevTasks.yml
+++ b/tasks/LocalDevTasks.yml
@@ -58,9 +58,17 @@ tasks:
     cmds:
       - dotnet lambda-test-tool start --lambda-emulator-port 5050 --config-storage-path ./lambda_test_tool
   
-  run-docs:
-    desc: Run MKDocs server locally
+  docs:serve:
+    desc: Serve docs locally with Zensical
     silent: true
     cmds:
-      - uv sync
-      - uv run mkdocs serve --livereload 
+      - echo "📖 Serving Docs"
+      - uv run zensical serve -f mkdocs.yml
+
+  docs:build:
+    desc: Build docs site with Zensical
+    silent: true
+    cmds:
+      - echo "📖 Building Docs"
+      - uv run zensical build -f mkdocs.yml
+      - echo "✅ Docs built"

--- a/uv.lock
+++ b/uv.lock
@@ -3,79 +3,6 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
-name = "babel"
-version = "2.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
-]
-
-[[package]]
-name = "backrefs"
-version = "6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/e3/bb3a439d5cb255c4774724810ad8073830fac9c9dee123555820c1bcc806/backrefs-6.1.tar.gz", hash = "sha256:3bba1749aafe1db9b915f00e0dd166cba613b6f788ffd63060ac3485dc9be231", size = 7011962, upload-time = "2025-11-15T14:52:08.323Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ee/c216d52f58ea75b5e1841022bbae24438b19834a29b163cb32aa3a2a7c6e/backrefs-6.1-py310-none-any.whl", hash = "sha256:2a2ccb96302337ce61ee4717ceacfbf26ba4efb1d55af86564b8bbaeda39cac1", size = 381059, upload-time = "2025-11-15T14:51:59.758Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/9a/8da246d988ded941da96c7ed945d63e94a445637eaad985a0ed88787cb89/backrefs-6.1-py311-none-any.whl", hash = "sha256:e82bba3875ee4430f4de4b6db19429a27275d95a5f3773c57e9e18abc23fd2b7", size = 392854, upload-time = "2025-11-15T14:52:01.194Z" },
-    { url = "https://files.pythonhosted.org/packages/37/c9/fd117a6f9300c62bbc33bc337fd2b3c6bfe28b6e9701de336b52d7a797ad/backrefs-6.1-py312-none-any.whl", hash = "sha256:c64698c8d2269343d88947c0735cb4b78745bd3ba590e10313fbf3f78c34da5a", size = 398770, upload-time = "2025-11-15T14:52:02.584Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/95/7118e935b0b0bd3f94dfec2d852fd4e4f4f9757bdb49850519acd245cd3a/backrefs-6.1-py313-none-any.whl", hash = "sha256:4c9d3dc1e2e558965202c012304f33d4e0e477e1c103663fd2c3cc9bb18b0d05", size = 400726, upload-time = "2025-11-15T14:52:04.093Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/72/6296bad135bfafd3254ae3648cd152980a424bd6fed64a101af00cc7ba31/backrefs-6.1-py314-none-any.whl", hash = "sha256:13eafbc9ccd5222e9c1f0bec563e6d2a6d21514962f11e7fc79872fd56cbc853", size = 412584, upload-time = "2025-11-15T14:52:05.233Z" },
-    { url = "https://files.pythonhosted.org/packages/02/e3/a4fa1946722c4c7b063cc25043a12d9ce9b4323777f89643be74cef2993c/backrefs-6.1-py39-none-any.whl", hash = "sha256:a9e99b8a4867852cad177a6430e31b0f6e495d65f8c6c134b68c14c3c95bf4b0", size = 381058, upload-time = "2025-11-15T14:52:06.698Z" },
-]
-
-[[package]]
-name = "certifi"
-version = "2025.11.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
-]
-
-[[package]]
-name = "charset-normalizer"
-version = "3.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/69/33ddede1939fdd074bce5434295f38fae7136463422fe4fd3e0e89b98062/charset_normalizer-3.4.4.tar.gz", hash = "sha256:94537985111c35f28720e43603b8e7b43a6ecfb2ce1d3058bbe955b73404e21a", size = 129418, upload-time = "2025-10-14T04:42:32.879Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/45/4b3a1239bbacd321068ea6e7ac28875b03ab8bc0aa0966452db17cd36714/charset_normalizer-3.4.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e1f185f86a6f3403aa2420e815904c67b2f9ebc443f045edd0de921108345794", size = 208091, upload-time = "2025-10-14T04:41:13.346Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/62/73a6d7450829655a35bb88a88fca7d736f9882a27eacdca2c6d505b57e2e/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b39f987ae8ccdf0d2642338faf2abb1862340facc796048b604ef14919e55ed", size = 147936, upload-time = "2025-10-14T04:41:14.461Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c5/adb8c8b3d6625bef6d88b251bbb0d95f8205831b987631ab0c8bb5d937c2/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3162d5d8ce1bb98dd51af660f2121c55d0fa541b46dff7bb9b9f86ea1d87de72", size = 144180, upload-time = "2025-10-14T04:41:15.588Z" },
-    { url = "https://files.pythonhosted.org/packages/91/ed/9706e4070682d1cc219050b6048bfd293ccf67b3d4f5a4f39207453d4b99/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:81d5eb2a312700f4ecaa977a8235b634ce853200e828fbadf3a9c50bab278328", size = 161346, upload-time = "2025-10-14T04:41:16.738Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/0d/031f0d95e4972901a2f6f09ef055751805ff541511dc1252ba3ca1f80cf5/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5bd2293095d766545ec1a8f612559f6b40abc0eb18bb2f5d1171872d34036ede", size = 158874, upload-time = "2025-10-14T04:41:17.923Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/83/6ab5883f57c9c801ce5e5677242328aa45592be8a00644310a008d04f922/charset_normalizer-3.4.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a8a8b89589086a25749f471e6a900d3f662d1d3b6e2e59dcecf787b1cc3a1894", size = 153076, upload-time = "2025-10-14T04:41:19.106Z" },
-    { url = "https://files.pythonhosted.org/packages/75/1e/5ff781ddf5260e387d6419959ee89ef13878229732732ee73cdae01800f2/charset_normalizer-3.4.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc7637e2f80d8530ee4a78e878bce464f70087ce73cf7c1caf142416923b98f1", size = 150601, upload-time = "2025-10-14T04:41:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/57/71be810965493d3510a6ca79b90c19e48696fb1ff964da319334b12677f0/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f8bf04158c6b607d747e93949aa60618b61312fe647a6369f88ce2ff16043490", size = 150376, upload-time = "2025-10-14T04:41:21.398Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/d5/c3d057a78c181d007014feb7e9f2e65905a6c4ef182c0ddf0de2924edd65/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:554af85e960429cf30784dd47447d5125aaa3b99a6f0683589dbd27e2f45da44", size = 144825, upload-time = "2025-10-14T04:41:22.583Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/8c/d0406294828d4976f275ffbe66f00266c4b3136b7506941d87c00cab5272/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:74018750915ee7ad843a774364e13a3db91682f26142baddf775342c3f5b1133", size = 162583, upload-time = "2025-10-14T04:41:23.754Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/24/e2aa1f18c8f15c4c0e932d9287b8609dd30ad56dbe41d926bd846e22fb8d/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c0463276121fdee9c49b98908b3a89c39be45d86d1dbaa22957e38f6321d4ce3", size = 150366, upload-time = "2025-10-14T04:41:25.27Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/5b/1e6160c7739aad1e2df054300cc618b06bf784a7a164b0f238360721ab86/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:362d61fd13843997c1c446760ef36f240cf81d3ebf74ac62652aebaf7838561e", size = 160300, upload-time = "2025-10-14T04:41:26.725Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/10/f882167cd207fbdd743e55534d5d9620e095089d176d55cb22d5322f2afd/charset_normalizer-3.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9a26f18905b8dd5d685d6d07b0cdf98a79f3c7a918906af7cc143ea2e164c8bc", size = 154465, upload-time = "2025-10-14T04:41:28.322Z" },
-    { url = "https://files.pythonhosted.org/packages/89/66/c7a9e1b7429be72123441bfdbaf2bc13faab3f90b933f664db506dea5915/charset_normalizer-3.4.4-cp313-cp313-win32.whl", hash = "sha256:9b35f4c90079ff2e2edc5b26c0c77925e5d2d255c42c74fdb70fb49b172726ac", size = 99404, upload-time = "2025-10-14T04:41:29.95Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
-    { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/35/7051599bd493e62411d6ede36fd5af83a38f37c4767b92884df7301db25d/charset_normalizer-3.4.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:da3326d9e65ef63a817ecbcc0df6e94463713b754fe293eaa03da99befb9a5bd", size = 207746, upload-time = "2025-10-14T04:41:33.773Z" },
-    { url = "https://files.pythonhosted.org/packages/10/9a/97c8d48ef10d6cd4fcead2415523221624bf58bcf68a802721a6bc807c8f/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8af65f14dc14a79b924524b1e7fffe304517b2bff5a58bf64f30b98bbc5079eb", size = 147889, upload-time = "2025-10-14T04:41:34.897Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bf/979224a919a1b606c82bd2c5fa49b5c6d5727aa47b4312bb27b1734f53cd/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:74664978bb272435107de04e36db5a9735e78232b85b77d45cfb38f758efd33e", size = 143641, upload-time = "2025-10-14T04:41:36.116Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/33/0ad65587441fc730dc7bd90e9716b30b4702dc7b617e6ba4997dc8651495/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:752944c7ffbfdd10c074dc58ec2d5a8a4cd9493b314d367c14d24c17684ddd14", size = 160779, upload-time = "2025-10-14T04:41:37.229Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ed/331d6b249259ee71ddea93f6f2f0a56cfebd46938bde6fcc6f7b9a3d0e09/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d1f13550535ad8cff21b8d757a3257963e951d96e20ec82ab44bc64aeb62a191", size = 159035, upload-time = "2025-10-14T04:41:38.368Z" },
-    { url = "https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecaae4149d99b1c9e7b88bb03e3221956f68fd6d50be2ef061b2381b61d20838", size = 152542, upload-time = "2025-10-14T04:41:39.862Z" },
-    { url = "https://files.pythonhosted.org/packages/16/85/276033dcbcc369eb176594de22728541a925b2632f9716428c851b149e83/charset_normalizer-3.4.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb6254dc36b47a990e59e1068afacdcd02958bdcce30bb50cc1700a8b9d624a6", size = 149524, upload-time = "2025-10-14T04:41:41.319Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/f2/6a2a1f722b6aba37050e626530a46a68f74e63683947a8acff92569f979a/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c8ae8a0f02f57a6e61203a31428fa1d677cbe50c93622b4149d5c0f319c1d19e", size = 150395, upload-time = "2025-10-14T04:41:42.539Z" },
-    { url = "https://files.pythonhosted.org/packages/60/bb/2186cb2f2bbaea6338cad15ce23a67f9b0672929744381e28b0592676824/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:47cc91b2f4dd2833fddaedd2893006b0106129d4b94fdb6af1f4ce5a9965577c", size = 143680, upload-time = "2025-10-14T04:41:43.661Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/a5/bf6f13b772fbb2a90360eb620d52ed8f796f3c5caee8398c3b2eb7b1c60d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:82004af6c302b5d3ab2cfc4cc5f29db16123b1a8417f2e25f9066f91d4411090", size = 162045, upload-time = "2025-10-14T04:41:44.821Z" },
-    { url = "https://files.pythonhosted.org/packages/df/c5/d1be898bf0dc3ef9030c3825e5d3b83f2c528d207d246cbabe245966808d/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7d8f6c26245217bd2ad053761201e9f9680f8ce52f0fcd8d0755aeae5b2152", size = 149687, upload-time = "2025-10-14T04:41:46.442Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/42/90c1f7b9341eef50c8a1cb3f098ac43b0508413f33affd762855f67a410e/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:799a7a5e4fb2d5898c60b640fd4981d6a25f1c11790935a44ce38c54e985f828", size = 160014, upload-time = "2025-10-14T04:41:47.631Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/4d3ee471e8145d12795ab655ece37baed0929462a86e72372fd25859047c/charset_normalizer-3.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99ae2cffebb06e6c22bdc25801d7b30f503cc87dbd283479e7b606f70aff57ec", size = 154044, upload-time = "2025-10-14T04:41:48.81Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/6f/8f7af07237c34a1defe7defc565a9bc1807762f672c0fde711a4b22bf9c0/charset_normalizer-3.4.4-cp314-cp314-win32.whl", hash = "sha256:f9d332f8c2a2fcbffe1378594431458ddbef721c1769d78e2cbc06280d8155f9", size = 99940, upload-time = "2025-10-14T04:41:49.946Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
-    { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
-]
-
-[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -97,36 +24,12 @@ wheels = [
 ]
 
 [[package]]
-name = "ghp-import"
-version = "2.1.0"
+name = "deepmerge"
+version = "2.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/3a/b0ba594708f1ad0bc735884b3ad854d3ca3bdc1d741e56e40bbda6263499/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20", size = 19890, upload-time = "2024-08-30T05:31:50.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
-]
-
-[[package]]
-name = "idna"
-version = "3.11"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
-]
-
-[[package]]
-name = "jinja2"
-version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+  { url = "https://files.pythonhosted.org/packages/2d/82/e5d2c1c67d19841e9edc74954c827444ae826978499bde3dfc1d007c8c11/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00", size = 13475, upload-time = "2024-08-30T05:31:48.659Z" },
 ]
 
 [[package]]
@@ -139,218 +42,40 @@ wheels = [
 ]
 
 [[package]]
-name = "markupsafe"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
-    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
-    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
-    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
-    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
-    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
-    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
-    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
-    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
-    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
-    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
-    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
-    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
-    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
-]
-
-[[package]]
-name = "mergedeep"
-version = "1.3.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
-]
-
-[[package]]
 name = "minimal-lambda-docs"
 version = "0.1.0"
 source = { virtual = "." }
-dependencies = [
-    { name = "mkdocs" },
-    { name = "mkdocs-material" },
+
+[package.dev-dependencies]
+dev = [
+  { name = "zensical" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "mkdocs", specifier = ">=1.6.1" },
-    { name = "mkdocs-material", specifier = ">=9.7.0" },
-]
 
-[[package]]
-name = "mkdocs"
-version = "1.6.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "ghp-import" },
-    { name = "jinja2" },
-    { name = "markdown" },
-    { name = "markupsafe" },
-    { name = "mergedeep" },
-    { name = "mkdocs-get-deps" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "pyyaml" },
-    { name = "pyyaml-env-tag" },
-    { name = "watchdog" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
-]
-
-[[package]]
-name = "mkdocs-get-deps"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mergedeep" },
-    { name = "platformdirs" },
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
-]
-
-[[package]]
-name = "mkdocs-material"
-version = "9.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "babel" },
-    { name = "backrefs" },
-    { name = "colorama" },
-    { name = "jinja2" },
-    { name = "markdown" },
-    { name = "mkdocs" },
-    { name = "mkdocs-material-extensions" },
-    { name = "paginate" },
-    { name = "pygments" },
-    { name = "pymdown-extensions" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/3b/111b84cd6ff28d9e955b5f799ef217a17bc1684ac346af333e6100e413cb/mkdocs_material-9.7.0.tar.gz", hash = "sha256:602b359844e906ee402b7ed9640340cf8a474420d02d8891451733b6b02314ec", size = 4094546, upload-time = "2025-11-11T08:49:09.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/87/eefe8d5e764f4cf50ed91b943f8e8f96b5efd65489d8303b7a36e2e79834/mkdocs_material-9.7.0-py3-none-any.whl", hash = "sha256:da2866ea53601125ff5baa8aa06404c6e07af3c5ce3d5de95e3b52b80b442887", size = 9283770, upload-time = "2025-11-11T08:49:06.26Z" },
-]
-
-[[package]]
-name = "mkdocs-material-extensions"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
-]
-
-[[package]]
-name = "packaging"
-version = "25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
-name = "paginate"
-version = "0.5.7"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
-]
+[package.metadata.requires-dev]
+dev = [{ name = "zensical", specifier = ">=0.0.33" }]
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+  { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.17.2"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/6d/af5378dbdb379fddd9a277f8b9888c027db480cde70028669ebd009d642a/pymdown_extensions-10.17.2.tar.gz", hash = "sha256:26bb3d7688e651606260c90fb46409fbda70bf9fdc3623c7868643a1aeee4713", size = 847344, upload-time = "2025-11-26T15:43:57.004Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/78/b93cb80bd673bdc9f6ede63d8eb5b4646366953df15667eb3603be57a2b1/pymdown_extensions-10.17.2-py3-none-any.whl", hash = "sha256:bffae79a2e8b9e44aef0d813583a8fea63457b7a23643a43988055b7b79b4992", size = 266556, upload-time = "2025-11-26T15:43:55.162Z" },
-]
-
-[[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+  { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]
@@ -390,67 +115,29 @@ wheels = [
 ]
 
 [[package]]
-name = "pyyaml-env-tag"
-version = "1.1"
+name = "zensical"
+version = "0.0.33"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+  { name = "click" },
+  { name = "deepmerge" },
+  { name = "markdown" },
+  { name = "pygments" },
+  { name = "pymdown-extensions" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/c2/dea4b86dc1ca2a7b55414017f12cfb12b5cfdf3a1ed7c77a04c271eb523b/zensical-0.0.33.tar.gz", hash = "sha256:05209cb4f80185c533e0d37c25d084ddc2050e3d5a4dd1b1812961c2ee0c3380", size = 3892278, upload-time = "2026-04-14T11:08:19.895Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
-]
-
-[[package]]
-name = "requests"
-version = "2.33.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "urllib3"
-version = "2.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "watchdog"
-version = "6.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
-    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
-    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
-    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
-    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+  { url = "https://files.pythonhosted.org/packages/74/5f/45d5200405420a9d8ac91cf9e7826622ea12f3198e8e6ac4ffb481eb53bf/zensical-0.0.33-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f658e3c241cfbb560bd8811116a9486cff7e04d7d5aed73569dd533c74187450", size = 12416748, upload-time = "2026-04-14T11:07:43.246Z" },
+  { url = "https://files.pythonhosted.org/packages/33/1e/aadaf31d6e4d20419ecedaf0b1c804e359ec23dcdb44c8d2bf6d8407080c/zensical-0.0.33-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f9813ac3256c28e2e2f1ba5c9fab1b4bca62bbe0e0f8e85ac22d33b068b1b08a", size = 12293372, upload-time = "2026-04-14T11:07:46.569Z" },
+  { url = "https://files.pythonhosted.org/packages/db/e5/838be8451ea8b2aecec39fbec3971060fc705e17f5741249740d9b6a6824/zensical-0.0.33-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3bad7ac71028769c5d1f3f84f448dbb7352db28d77095d1b40a8d1b0aa34ec30", size = 12659832, upload-time = "2026-04-14T11:07:50.754Z" },
+  { url = "https://files.pythonhosted.org/packages/1e/5c/dd957d7c83efc13a70a6058d4190a3afcf29942aefb391120bca5466347d/zensical-0.0.33-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:06bb039daf044547c9400a52f9493b3cd486ba9baef3324fdcffd2e26e61105f", size = 12603847, upload-time = "2026-04-14T11:07:53.698Z" },
+  { url = "https://files.pythonhosted.org/packages/b7/99/dd6ccc392ece1f34fb20ea339a01717badbbeb2fba1d4f3019a5028d0bcc/zensical-0.0.33-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:260238062b3139ece0edab93f4dbe7a12923453091f5aa580dfd73e799388076", size = 12956236, upload-time = "2026-04-14T11:07:56.728Z" },
+  { url = "https://files.pythonhosted.org/packages/f4/76/e0a1b884eadf6afa7e2d56c90c268eec36836ac27e96ef250c0129e55417/zensical-0.0.33-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7dff0f4afda7b8586bc4ab2a5684bce5b282232dd4e0cad3be4c73fedd264425", size = 12701944, upload-time = "2026-04-14T11:07:59.928Z" },
+  { url = "https://files.pythonhosted.org/packages/38/38/e1ff13461e406864fa2b23fc828822659a7dbac5c79398f724d17f088540/zensical-0.0.33-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:207b4d81b208d75b97dc7bd318804550b886a3e852ef67429ef0e6b9442839d1", size = 12835444, upload-time = "2026-04-14T11:08:02.998Z" },
+  { url = "https://files.pythonhosted.org/packages/41/04/7d24d52d6903fc5c511633afe8b5716fef19da09685327665cc127f61648/zensical-0.0.33-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:06d2f57f7bc8cc8fd904386020ea1365eebc411e8698a871e9525c885abca574", size = 12878419, upload-time = "2026-04-14T11:08:06.054Z" },
+  { url = "https://files.pythonhosted.org/packages/9a/ec/87fc9e360c694ab006363c7834639eccafd0d26a487cd63dd609bd68f36a/zensical-0.0.33-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:c2851b82d83aa0b2ae4f8e99731cfeedeecebfa04e6b3fc4d375deca629fa240", size = 13022474, upload-time = "2026-04-14T11:08:09.007Z" },
+  { url = "https://files.pythonhosted.org/packages/10/b3/0bf174ab6ceedb31d9af462073b5339c894b2084a27d42cb9f0906050d76/zensical-0.0.33-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:90daaf512b0429d7b9147ad5e6085b455d24803eff18b508aed738ca65444683", size = 12975233, upload-time = "2026-04-14T11:08:12.535Z" },
+  { url = "https://files.pythonhosted.org/packages/a9/27/7cc3c2d284698647f60f3b823e0101e619c87edf158d47ee11bf4bfb6228/zensical-0.0.33-cp310-abi3-win32.whl", hash = "sha256:2701820597fe19361a12371129927c58c19633dcaa5f6986d610dce58cecd8c4", size = 12012664, upload-time = "2026-04-14T11:08:14.977Z" },
+  { url = "https://files.pythonhosted.org/packages/25/0b/6be5c2fdaf9f1600577e7ba5e235d86b72a26f6af389efb146f978f76ac3/zensical-0.0.33-cp310-abi3-win_amd64.whl", hash = "sha256:a5a0911b4247708a55951b74c459f4d5faec5daaf287d23a2e1f0d96be1e647f", size = 12206255, upload-time = "2026-04-14T11:08:17.375Z" },
 ]


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

Migrates the project documentation site to use the Zensical authoring system. Adds a comprehensive set of authoring and configuration reference docs under `.agents/skills/zensical-site/references/`, updates the docs workflow, cleans up outdated content (changelog nav entry, SonarCloud badge), and optimizes MkDocs dependencies.

---

## 🔄 Changes

- Add `zensical-site` skill with full reference docs (authoring, content types, voice/tone, configuration, front matter, markdown/links, callouts, layout, etc.)
- Add page draft template
- Update `docs.yaml` workflow for Zensical-compatible build
- Remove outdated changelog from navigation and reformat index
- Remove SonarCloud quality gate badge from README
- Optimize `pyproject.toml` dependencies and rebuild `uv.lock`
- Update local dev tasks in `LocalDevTasks.yml`

---

## ✅ Checklist

- [x] My changes build cleanly
- [x] I've added/updated relevant tests
- [x] I've added/updated documentation or README
- [x] I've followed the coding style for this project
- [x] I've tested the changes locally (if applicable)

---

## 🧪 Related Issues or PRs

Closes #208 

---

## 💬 Notes for Reviewers

Reference docs under `.agents/skills/zensical-site/references/` are authoring guides for Claude — not end-user docs. The workflow change in `docs.yaml` aligns with the Zensical build pipeline.