### PR TITLE
fix(deps): pin source generator Roslyn common package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="[5.0.0]" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="[5.0.0]" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="[5.0.0]" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.3" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />

--- a/src/MinimalLambda.SourceGenerators/MinimalLambda.SourceGenerators.csproj
+++ b/src/MinimalLambda.SourceGenerators/MinimalLambda.SourceGenerators.csproj
@@ -25,6 +25,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp"/>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" PrivateAssets="all"/>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all"/>
     <PackageReference Include="Scriban" IncludeAssets="Build"/>
     <PackageReference Include="System.Threading.Tasks.Extensions"/>


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

Pins the source generator's compiler-facing Roslyn references to `5.0.0` so the generator remains loadable by compiler hosts using Roslyn 5.0. The existing `Microsoft.CodeAnalysis.CSharp` exact pin is kept, and `Microsoft.CodeAnalysis.Common` is now pinned and referenced directly to make the dependency floor explicit.

---

## ✅ Checklist

- [x] My changes build cleanly
- [ ] I’ve added/updated relevant tests
- [ ] I’ve added/updated documentation or README
- [x] I’ve tested the changes locally (if applicable)

---

## 💬 Notes for Reviewers

Validation run:

- `DOTNET_NOLOGO=1 dotnet restore src/MinimalLambda.SourceGenerators/MinimalLambda.SourceGenerators.csproj`
- `dotnet list src/MinimalLambda.SourceGenerators/MinimalLambda.SourceGenerators.csproj package --include-transitive` confirmed `Microsoft.CodeAnalysis.Common` and `Microsoft.CodeAnalysis.CSharp` resolve to `5.0.0`, while `Microsoft.CodeAnalysis.Analyzers` remains at `5.3.0`.
- `DOTNET_NOLOGO=1 dotnet build src/MinimalLambda.SourceGenerators/MinimalLambda.SourceGenerators.csproj --no-restore`
- MCP test runner: `tests/MinimalLambda.SourceGenerators.UnitTests/MinimalLambda.SourceGenerators.UnitTests.csproj` passed 95 tests.

`task format` was intentionally not completed per follow-up instruction to focus on the package change.