### PR TITLE
fix: suppress net11 pack warning

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup Condition="$(TargetFrameworks.Contains('net11.0'))">
+    <!-- NU5104: net11.0 dependencies are prerelease while .NET 11 is in preview. -->
+    <NoWarn>$(NoWarn);NU5104</NoWarn>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

Adds a root `Directory.Build.targets` pack-time suppression for `NU5104` only when a project ships a `net11.0` target. This lets stable package versions pack while .NET 11 dependencies are still preview-only.

## Changes

- Suppresses `NU5104` when `TargetFrameworks` contains `net11.0`.
- Keeps suppression scoped to net11-targeting packages instead of globally disabling prerelease dependency validation.

## Validation

- Ran `dotnet pack --configuration Release --output /tmp/minimal-lambda-pack-test /p:Version=2.6.0` successfully.

## Notes for Reviewers

- Existing `Directory.Build.props` suppression only applied when `TargetFramework == net11.0`; pack fails in outer-build context where `TargetFrameworks` is available instead.
