### PR TITLE
ci(github): align NuGet publish workflows

### DIFF
--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -1,7 +1,6 @@
 name: Publish Preview
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - main
@@ -12,6 +11,7 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - '**.md'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/publish-preview.yaml
+++ b/.github/workflows/publish-preview.yaml
@@ -1,8 +1,10 @@
 name: Publish Preview
 
 on:
+  workflow_dispatch:
   push:
-    branches: [main]
+    branches:
+      - main
     paths-ignore:
       - 'docs/**'
       - 'mkdocs.yml'
@@ -10,18 +12,15 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - '**.md'
-  workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
-
-concurrency:
-  group: publish-preview-${{ github.ref }}
-  cancel-in-progress: true
+  contents: read
 
 jobs:
   build:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: LayeredCraft/devops-templates/.github/workflows/publish-preview.yml@v10.1
     with:
       solution: MinimalLambda.sln
@@ -29,8 +28,6 @@ jobs:
       prereleaseIdentifier: preview
       hasTests: false
       buildConfiguration: Release
-      artifact_name: nuget-packages
-    secrets: inherit
 
   push:
     needs: build
@@ -42,4 +39,3 @@ jobs:
       - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.1
         with:
           nuget_user: ${{ secrets.NUGET_USER }}
-          artifact_name: nuget-packages

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -5,17 +5,18 @@ on:
     types: [published]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
+    permissions:
+      contents: write
     uses: LayeredCraft/devops-templates/.github/workflows/publish-release.yml@v10.1
     with:
       solution: MinimalLambda.sln
       dotnetVersion: 11.0.x
       hasTests: false
       buildConfiguration: Release
-    secrets: inherit
 
   push:
     needs: build
@@ -27,4 +28,3 @@ jobs:
       - uses: LayeredCraft/devops-templates/.github/actions/nuget-push@v10.1
         with:
           nuget_user: ${{ secrets.NUGET_USER }}
-          artifact_name: nuget-packages


### PR DESCRIPTION
## Summary

Align NuGet publish workflows with working LayeredCraft repositories such as `dynamodb-efcore-provider`. This keeps trusted publishing wired through the org-level `NUGET_USER` secret and caller-owned OIDC push job.

## Changes

- Set top-level publish workflow permissions to `contents: read`.
- Move elevated `contents: write` / `pull-requests: write` permissions onto the build jobs.
- Remove explicit artifact-name overrides and rely on shared workflow/action defaults.
- Keep push jobs using `id-token: write` and `${{ secrets.NUGET_USER }}`.

## Validation

- YAML parsed locally with Ruby `YAML.load_file`.
- Compared against existing LayeredCraft publish workflows.

## Notes for Reviewers

Publishing still depends on the org-level `NUGET_USER` secret being available to this repo and NuGet trusted publisher policies matching the workflow paths.
