### PR TITLE
refactor: align formatter rules and code layout

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,6 @@ trim_trailing_whitespace = true
 indent_size = 4
 max_line_length = 120
 
-[{*HostFactoryResolver.cs,docs/**}]
+[{*HostFactoryResolver.cs,docs/**,.agents/**}]
 ij_formatter_enabled = false
 resharper_disable_formatter = true

--- a/MinimalLambda.sln.DotSettings
+++ b/MinimalLambda.sln.DotSettings
@@ -1,7 +1,15 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_LINQ_QUERY/@EntryValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_PARAMETER/@EntryValue">False</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EMPTY_BLOCK_STYLE/@EntryValue">TOGETHER_SAME_LINE</s:String>
+﻿<wpf:ResourceDictionary xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xml:space="preserve">
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ACCESSOR_OWNER_BODY/@EntryValue">ExpressionBody</s:String>
+  <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/BRACES_FOR_IFELSE/@EntryValue">NotRequiredForBoth</s:String>
+  <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/CONSTRUCTOR_OR_DESTRUCTOR_BODY/@EntryValue">ExpressionBody</s:String>
+  <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/LOCAL_FUNCTION_BODY/@EntryValue">ExpressionBody</s:String>
+  <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/METHOD_OR_OPERATOR_BODY/@EntryValue">ExpressionBody</s:String>
+  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/USE_HEURISTICS_FOR_BODY_STYLE/@EntryValue">False</s:Boolean>
+  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_LINQ_QUERY/@EntryValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_BINARY_EXPRESSIONS_CHAIN/@EntryValue">False</s:Boolean>
+  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_PARAMETER/@EntryValue">False</s:Boolean>
+  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALIGN_MULTILINE_STATEMENT_CONDITIONS/@EntryValue">False</s:Boolean>
+  <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EMPTY_BLOCK_STYLE/@EntryValue">TOGETHER_SAME_LINE</s:String>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_FOR_STMT/@EntryValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_FOREACH_STMT/@EntryValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/INDENT_NESTED_LOCK_STMT/@EntryValue">True</s:Boolean>
@@ -13,7 +21,7 @@
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_EMBEDDED_ARRANGEMENT/@EntryValue">False</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_EXPR_MEMBER_ARRANGEMENT/@EntryValue">False</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_INITIALIZER_ARRANGEMENT/@EntryValue">False</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_INVOCATION_PARENS_ARRANGEMENT/@EntryValue">False</s:Boolean>
+  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_INVOCATION_PARENS_ARRANGEMENT/@EntryValue">False</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_LIST_PATTERNS_ARRANGEMENT/@EntryValue">False</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_PRIMARY_CONSTRUCTOR_DECLARATION_PARENS_ARRANGEMENT/@EntryValue">False</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_PROPERTY_PATTERNS_ARRANGEMENT/@EntryValue">False</s:Boolean>
@@ -26,13 +34,14 @@
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_RECORD_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">ALWAYS</s:String>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ANONYMOUSMETHOD_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_EMBEDDED_STATEMENT_ON_SAME_LINE/@EntryValue">NEVER</s:String>
-	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PREFER_WRAP_AROUND_EQ/@EntryValue">STRONGLY</s:String>
+  <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PREFER_WRAP_AROUND_EQ/@EntryValue">STRONGLY</s:String>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/STICK_COMMENT/@EntryValue">False</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_DECLARATION_LPAR/@EntryValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_INVOCATION_LPAR/@EntryValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_PROPERTY_IN_CHAINED_METHOD_CALLS/@EntryValue">True</s:Boolean>
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARRAY_INITIALIZER_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
-  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_ARROW_WITH_EXPRESSIONS/@EntryValue">False</s:Boolean>
+  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_ARROW_WITH_EXPRESSIONS/@EntryValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_BINARY_OPSIGN/@EntryValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_EXTENDS_COLON/@EntryValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_FIRST_METHOD_CALL/@EntryValue">True</s:Boolean>
@@ -41,10 +50,12 @@
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_BINARY_EXPRESSIONS/@EntryValue">CHOP_IF_LONG</s:String>
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_BINARY_PATTERNS/@EntryValue">CHOP_IF_LONG</s:String>
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_METHOD_CALLS/@EntryValue">CHOP_IF_LONG</s:String>
-	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_COMMENTS/@EntryValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_COMMENTS/@EntryValue">True</s:Boolean>
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_EXTENDS_LIST_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LAMBDA_AND_ANONYMOUS_FUNCTION_PARAMETERS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIST_PATTERN/@EntryValue">CHOP_IF_LONG</s:String>
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_PARAMETERS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+  <s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_ATTRIBUTE_LENGTH_FOR_SAME_LINE/@EntryValue">100</s:Int64>
   <s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>

--- a/MinimalLambda.sln.DotSettings
+++ b/MinimalLambda.sln.DotSettings
@@ -41,7 +41,7 @@
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_PROPERTY_IN_CHAINED_METHOD_CALLS/@EntryValue">True</s:Boolean>
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
   <s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARRAY_INITIALIZER_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
-  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_ARROW_WITH_EXPRESSIONS/@EntryValue">True</s:Boolean>
+  <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_ARROW_WITH_EXPRESSIONS/@EntryValue">False</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_BINARY_OPSIGN/@EntryValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_EXTENDS_COLON/@EntryValue">True</s:Boolean>
   <s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_FIRST_METHOD_CALL/@EntryValue">True</s:Boolean>

--- a/src/MinimalLambda.SourceGenerators/Diagnostics/DiagnosticGenerator.cs
+++ b/src/MinimalLambda.SourceGenerators/Diagnostics/DiagnosticGenerator.cs
@@ -13,22 +13,26 @@ internal static class DiagnosticGenerator
 
         diagnostics.AddRange(
             compilationInfo
-                .MapHandlerInvocationInfos.SelectMany(m => m.DiagnosticInfos)
+                .MapHandlerInvocationInfos
+                .SelectMany(m => m.DiagnosticInfos)
                 .Select(d => d.ToDiagnostic()));
 
         diagnostics.AddRange(
             compilationInfo
-                .OnInitInvocationInfos.SelectMany(m => m.DiagnosticInfos)
+                .OnInitInvocationInfos
+                .SelectMany(m => m.DiagnosticInfos)
                 .Select(d => d.ToDiagnostic()));
 
         diagnostics.AddRange(
             compilationInfo
-                .OnShutdownInvocationInfos.SelectMany(m => m.DiagnosticInfos)
+                .OnShutdownInvocationInfos
+                .SelectMany(m => m.DiagnosticInfos)
                 .Select(d => d.ToDiagnostic()));
 
         diagnostics.AddRange(
             compilationInfo
-                .UseMiddlewareTInfos.SelectMany(m => m.DiagnosticInfos)
+                .UseMiddlewareTInfos
+                .SelectMany(m => m.DiagnosticInfos)
                 .Select(d => d.ToDiagnostic()));
 
         return diagnostics;

--- a/src/MinimalLambda.SourceGenerators/Extensions/MethodSymbolExtensions.cs
+++ b/src/MinimalLambda.SourceGenerators/Extensions/MethodSymbolExtensions.cs
@@ -14,7 +14,8 @@ internal static class MethodSymbolExtensions
         {
             var returnType = methodSymbol.ReturnType.QualifiedNullableName;
             var parameters = methodSymbol
-                .Parameters.Select((p, i) =>
+                .Parameters
+                .Select((p, i) =>
                 {
                     var type = p.Type.QualifiedNullableName;
                     var defaultValue = p.IsOptional ? " = default" : "";
@@ -101,7 +102,7 @@ internal static class MethodSymbolExtensions
             var originalDef = namedReturnType.OriginalDefinition;
 
             if ((originalDef.Equals(taskOfT, SymbolEqualityComparer.Default)
-                 || originalDef.Equals(valueTaskOfT, SymbolEqualityComparer.Default))
+                    || originalDef.Equals(valueTaskOfT, SymbolEqualityComparer.Default))
                 && namedReturnType.TypeArguments.Length > 0)
                 return namedReturnType.TypeArguments[0];
 

--- a/src/MinimalLambda.SourceGenerators/Extensions/ParameterSymbolExtensions.cs
+++ b/src/MinimalLambda.SourceGenerators/Extensions/ParameterSymbolExtensions.cs
@@ -16,7 +16,7 @@ internal static class ParameterSymbolExtensions
         parameterSymbol
             .GetAttributes()
             .Any(a => a.AttributeClass is not null
-                      && context.WellKnownTypes.IsType(a.AttributeClass, attributeType));
+                && context.WellKnownTypes.IsType(a.AttributeClass, attributeType));
 
     extension(IParameterSymbol parameterSymbol)
     {
@@ -24,10 +24,10 @@ internal static class ParameterSymbolExtensions
             parameterSymbol
                 .GetAttributes()
                 .Any(attribute => attribute.AttributeClass is not null
-                                  && context.WellKnownTypes.IsType(
-                                      attribute.AttributeClass,
-                                      WellKnownType.MinimalLambda_Builder_EventAttribute,
-                                      WellKnownType.MinimalLambda_Builder_FromEventAttribute));
+                    && context.WellKnownTypes.IsType(
+                        attribute.AttributeClass,
+                        WellKnownType.MinimalLambda_Builder_EventAttribute,
+                        WellKnownType.MinimalLambda_Builder_FromEventAttribute));
 
         internal DiagnosticResult<(string Assignment, string? Key)> GetDiParameterAssignment(
             GeneratorContext context)
@@ -35,7 +35,7 @@ internal static class ParameterSymbolExtensions
             var paramType = parameterSymbol.Type.QualifiedNullableName;
 
             var isRequired = parameterSymbol.IsOptional
-                             || parameterSymbol.NullableAnnotation == NullableAnnotation.Annotated;
+                || parameterSymbol.NullableAnnotation == NullableAnnotation.Annotated;
 
             return parameterSymbol
                 .IsFromKeyedService(context)
@@ -58,10 +58,10 @@ internal static class ParameterSymbolExtensions
             parameterSymbol
                 .GetAttributes()
                 .FirstOrDefault(attribute => attribute is { AttributeClass: not null }
-                                             && context.WellKnownTypes.IsType(
-                                                 attribute.AttributeClass,
-                                                 WellKnownType
-                                                     .Microsoft_Extensions_DependencyInjection_FromKeyedServicesAttribute))
+                    && context.WellKnownTypes.IsType(
+                        attribute.AttributeClass,
+                        WellKnownType
+                            .Microsoft_Extensions_DependencyInjection_FromKeyedServicesAttribute))
                 ?.ExtractKeyedServiceKey()
                 .Bind<(bool, string?)>(key => (true, key))
             ?? (false, null);
@@ -119,8 +119,10 @@ internal static class ParameterSymbolExtensions
                 ArgumentList: { } argumentList,
             }
                 ? argumentList
-                    .Arguments.ElementAtOrDefault(index)
-                    ?.Expression.GetLocation()
+                    .Arguments
+                    .ElementAtOrDefault(index)
+                    ?.Expression
+                    .GetLocation()
                     .ToLocationInfo()
                 : null;
     }

--- a/src/MinimalLambda.SourceGenerators/MinimalLambdaGenerator.cs
+++ b/src/MinimalLambda.SourceGenerators/MinimalLambdaGenerator.cs
@@ -29,14 +29,16 @@ public class MinimalLambdaGenerator : IIncrementalGenerator
 
         // handler registration calls
         var registrationCalls = context
-            .SyntaxProvider.CreateSyntaxProvider(
+            .SyntaxProvider
+            .CreateSyntaxProvider(
                 HandlerSyntaxProvider.Predicate,
                 HandlerSyntaxProvider.Transformer)
             .WhereNotNull();
 
         // find UseMiddleware<T>() calls
         var useMiddlewareTCalls = context
-            .SyntaxProvider.CreateSyntaxProvider(
+            .SyntaxProvider
+            .CreateSyntaxProvider(
                 UseMiddlewareTSyntaxProvider.Predicate,
                 UseMiddlewareTSyntaxProvider.Transformer)
             .WhereNotNull();

--- a/src/MinimalLambda.SourceGenerators/Models/Handlers/LifecycleHandlerParameterInfo.cs
+++ b/src/MinimalLambda.SourceGenerators/Models/Handlers/LifecycleHandlerParameterInfo.cs
@@ -29,8 +29,8 @@ internal static class LifecycleHandlerParameterInfoExtensions
 
             // context
             if (context.WellKnownTypes.IsType(
-                    parameter.Type,
-                    WellKnownType.MinimalLambda_ILambdaLifecycleContext))
+                parameter.Type,
+                WellKnownType.MinimalLambda_ILambdaLifecycleContext))
                 return DiagnosticResult<LifecycleHandlerParameterInfo>.Success(
                     parameterInfo with
                     {
@@ -39,8 +39,8 @@ internal static class LifecycleHandlerParameterInfoExtensions
 
             // cancellation token
             if (context.WellKnownTypes.IsType(
-                    parameter.Type,
-                    WellKnownType.System_Threading_CancellationToken))
+                parameter.Type,
+                WellKnownType.System_Threading_CancellationToken))
                 return DiagnosticResult<LifecycleHandlerParameterInfo>.Success(
                     parameterInfo with
                     {

--- a/src/MinimalLambda.SourceGenerators/Models/Handlers/LifecycleMethodInfo.cs
+++ b/src/MinimalLambda.SourceGenerators/Models/Handlers/LifecycleMethodInfo.cs
@@ -44,9 +44,9 @@ internal static class LifecycleMethodInfoExtensions
                 out var unwrappedReturnType);
 
             var unwrappedReturnIsBool = hasResponse
-                                        && context.WellKnownTypes.IsType(
-                                            unwrappedReturnType!,
-                                            WellKnownTypeData.WellKnownType.System_Boolean);
+                && context.WellKnownTypes.IsType(
+                    unwrappedReturnType!,
+                    WellKnownTypeData.WellKnownType.System_Boolean);
 
             /*
              * Return rules:
@@ -57,11 +57,10 @@ internal static class LifecycleMethodInfoExtensions
              */
 
             var returnIsTaskBool = methodSymbol.ReturnType is INamedTypeSymbol namedTypeSymbol
-                                   && context.WellKnownTypes.IsType(
-                                       namedTypeSymbol.ConstructedFrom,
-                                       WellKnownTypeData.WellKnownType
-                                           .System_Threading_Tasks_Task_T)
-                                   && unwrappedReturnIsBool;
+                && context.WellKnownTypes.IsType(
+                    namedTypeSymbol.ConstructedFrom,
+                    WellKnownTypeData.WellKnownType.System_Threading_Tasks_Task_T)
+                && unwrappedReturnIsBool;
 
             var shouldAwait = isAwaitable && !returnIsTaskBool;
 

--- a/src/MinimalLambda.SourceGenerators/Models/Handlers/MapHandlerMethodInfo.cs
+++ b/src/MinimalLambda.SourceGenerators/Models/Handlers/MapHandlerMethodInfo.cs
@@ -67,9 +67,9 @@ internal static class MapHandlerMethodInfoExtensions
                 out var unwrappedReturnType);
 
             var isReturnTypeStream = hasResponse
-                                     && context.WellKnownTypes.IsType(
-                                         methodSymbol.ReturnType,
-                                         WellKnownType.System_IO_Stream);
+                && context.WellKnownTypes.IsType(
+                    methodSymbol.ReturnType,
+                    WellKnownType.System_IO_Stream);
 
             var hasEvent = assignments.Any(a => a.IsEvent);
 

--- a/src/MinimalLambda.SourceGenerators/Models/Handlers/MapHandlerParameterInfo.cs
+++ b/src/MinimalLambda.SourceGenerators/Models/Handlers/MapHandlerParameterInfo.cs
@@ -52,9 +52,9 @@ internal static class MapHandlerParameterInfoExtensions
 
             // context
             if (context.WellKnownTypes.IsType(
-                    parameter.Type,
-                    WellKnownType.Amazon_Lambda_Core_ILambdaContext,
-                    WellKnownType.MinimalLambda_ILambdaInvocationContext))
+                parameter.Type,
+                WellKnownType.Amazon_Lambda_Core_ILambdaContext,
+                WellKnownType.MinimalLambda_ILambdaInvocationContext))
                 return DiagnosticResult<MapHandlerParameterInfo>.Success(
                     parameterInfo with
                     {
@@ -63,8 +63,8 @@ internal static class MapHandlerParameterInfoExtensions
 
             // cancellation token
             if (context.WellKnownTypes.IsType(
-                    parameter.Type,
-                    WellKnownType.System_Threading_CancellationToken))
+                parameter.Type,
+                WellKnownType.System_Threading_CancellationToken))
                 return DiagnosticResult<MapHandlerParameterInfo>.Success(
                     parameterInfo with
                     {

--- a/src/MinimalLambda.SourceGenerators/Models/Middleware/MiddlewareClassInfo.cs
+++ b/src/MinimalLambda.SourceGenerators/Models/Middleware/MiddlewareClassInfo.cs
@@ -57,7 +57,8 @@ internal static class MiddlewareExtensions
             // get constructor parameters
             var parameterInfos = constructor is not null
                 ? constructor
-                    .Parameters.CollectDiagnosticResults(parameter =>
+                    .Parameters
+                    .CollectDiagnosticResults(parameter =>
                         MiddlewareParameterInfo.Create(parameter, context))
                     .Map(results =>
                     {
@@ -94,14 +95,13 @@ internal static class MiddlewareExtensions
     {
         // 1. Get constructors annotated with `[MiddlewareConstructor]`
         var constructors = namedTypeSymbol
-            .InstanceConstructors.Where(c =>
-                c
-                    .GetAttributes()
-                    .Any(a => a.AttributeClass is not null
-                              && context.WellKnownTypes.IsType(
-                                  a.AttributeClass,
-                                  WellKnownType
-                                      .MinimalLambda_Builder_MiddlewareConstructorAttribute)))
+            .InstanceConstructors
+            .Where(c => c
+                .GetAttributes()
+                .Any(a => a.AttributeClass is not null
+                    && context.WellKnownTypes.IsType(
+                        a.AttributeClass,
+                        WellKnownType.MinimalLambda_Builder_MiddlewareConstructorAttribute)))
             .ToArray();
 
         return constructors.Length switch
@@ -122,7 +122,8 @@ internal static class MiddlewareExtensions
             // 2. default to constructor with most parameters
             _ => (
                 MethodSymbol: namedTypeSymbol
-                    .InstanceConstructors.OrderByDescending(c => c.Parameters.Length)
+                    .InstanceConstructors
+                    .OrderByDescending(c => c.Parameters.Length)
                     .First(), DiagnosticInfos: []),
         };
     }

--- a/src/MinimalLambda.SourceGenerators/Models/Middleware/MiddlewareParameterInfo.cs
+++ b/src/MinimalLambda.SourceGenerators/Models/Middleware/MiddlewareParameterInfo.cs
@@ -41,11 +41,11 @@ internal static class MiddlewareParameterInfoExtensions
 
             // determine if it has a `[FromServices]` attribute
             var fromServices = !fromArguments
-                               && parameterSymbol.IsDecoratedWithAttribute(
-                                   context,
-                                   WellKnownType.MinimalLambda_Builder_FromServicesAttribute,
-                                   WellKnownType
-                                       .Microsoft_Extensions_DependencyInjection_FromKeyedServicesAttribute);
+                && parameterSymbol.IsDecoratedWithAttribute(
+                    context,
+                    WellKnownType.MinimalLambda_Builder_FromServicesAttribute,
+                    WellKnownType
+                        .Microsoft_Extensions_DependencyInjection_FromKeyedServicesAttribute);
 
             // assignment from services
             return parameterSymbol

--- a/src/MinimalLambda.SourceGenerators/Models/Middleware/UseMiddlewareTInfo.cs
+++ b/src/MinimalLambda.SourceGenerators/Models/Middleware/UseMiddlewareTInfo.cs
@@ -31,18 +31,20 @@ internal static class UseMiddlewareTInfoExtensions
 
             var interceptableLocation =
                 (context.SemanticModel.GetInterceptableLocation(
-                     invocationExpressionSyntax,
-                     context.CancellationToken)
-                 ?? throw new InvalidOperationException(
-                     "Interceptable location is null (Should not happen)"))
+                        invocationExpressionSyntax,
+                        context.CancellationToken)
+                    ?? throw new InvalidOperationException(
+                        "Interceptable location is null (Should not happen)"))
                 .ToInterceptableLocationInfo()
                 .Attribute;
 
             var middlewareClassType = invocationOperation
-                .TargetMethod.TypeArguments.FirstOrDefault()
+                .TargetMethod
+                .TypeArguments
+                .FirstOrDefault()
                 .Map(typeSymbol => typeSymbol as INamedTypeSymbol
-                                   ?? throw new InvalidOperationException(
-                                       "Middleware class type is not INamedTypeSymbol (Should not happen)"));
+                    ?? throw new InvalidOperationException(
+                        "Middleware class type is not INamedTypeSymbol (Should not happen)"));
 
             TryGetLocationInfo(invocationExpressionSyntax, out var typeArgumentLocation);
 

--- a/src/MinimalLambda.SourceGenerators/SyntaxProviders/HandlerSyntaxProvider.cs
+++ b/src/MinimalLambda.SourceGenerators/SyntaxProviders/HandlerSyntaxProvider.cs
@@ -137,7 +137,8 @@ internal static class HandlerSyntaxProvider
         ISymbol symbol,
         SemanticModel? semanticModel) =>
         symbol
-            .DeclaringSyntaxReferences.Select(syntaxReference => syntaxReference.GetSyntax())
+            .DeclaringSyntaxReferences
+            .Select(syntaxReference => syntaxReference.GetSyntax())
             .OfType<VariableDeclaratorSyntax>()
             .Where(syn => syn.Initializer?.Value is not null)
             .Select(syn =>

--- a/src/MinimalLambda.Testing/HostFactoryResolver.cs
+++ b/src/MinimalLambda.Testing/HostFactoryResolver.cs
@@ -41,8 +41,8 @@ internal sealed class HostFactoryResolver
             return Timeout.InfiniteTimeSpan;
 
         if (uint.TryParse(
-                Environment.GetEnvironmentVariable(TimeoutEnvironmentKey),
-                out var timeoutInSeconds))
+            Environment.GetEnvironmentVariable(TimeoutEnvironmentKey),
+            out var timeoutInSeconds))
             return TimeSpan.FromSeconds((int)timeoutInSeconds);
 
         return TimeSpan.FromMinutes(5);
@@ -281,7 +281,7 @@ internal sealed class HostFactoryResolver
                             "The entry point exited without ever building an IHost."));
                 }
                 catch (TargetInvocationException tie) when (tie.InnerException?.GetType().Name
-                                                            == "HostAbortedException")
+                    == "HostAbortedException")
                 {
                     // The host was stopped by our own logic
                 }

--- a/src/MinimalLambda.Testing/LambdaApplicationFactory.cs
+++ b/src/MinimalLambda.Testing/LambdaApplicationFactory.cs
@@ -166,8 +166,8 @@ public class LambdaApplicationFactory<TEntryPoint> : IDisposable, IAsyncDisposab
     ///     <see cref="IHostBuilder" />.
     /// </param>
     /// <returns>A new <see cref="LambdaApplicationFactory{TEntryPoint}" />.</returns>
-    public LambdaApplicationFactory<TEntryPoint> WithHostBuilder(
-        Action<IHostBuilder> configuration) =>
+    public LambdaApplicationFactory<TEntryPoint> WithHostBuilder(Action<IHostBuilder> configuration)
+        =>
         WithHostBuilderCore(configuration);
 
     /// <summary>
@@ -412,11 +412,8 @@ public class LambdaApplicationFactory<TEntryPoint> : IDisposable, IAsyncDisposab
             var entryPointAssemblyName = typeof(TEntryPoint).Assembly.GetName().Name;
 
             // Find the list of projects referencing TEntryPoint.
-            var candidates = context.CompileLibraries.Where(library =>
-                library.Dependencies.Any(d => string.Equals(
-                    d.Name,
-                    entryPointAssemblyName,
-                    StringComparison.Ordinal)));
+            var candidates = context.CompileLibraries.Where(library => library.Dependencies.Any(d
+                => string.Equals(d.Name, entryPointAssemblyName, StringComparison.Ordinal)));
 
             var testAssemblies = new List<Assembly>();
             foreach (var candidate in candidates)

--- a/src/MinimalLambda.Testing/LambdaApplicationFactory.cs
+++ b/src/MinimalLambda.Testing/LambdaApplicationFactory.cs
@@ -166,8 +166,8 @@ public class LambdaApplicationFactory<TEntryPoint> : IDisposable, IAsyncDisposab
     ///     <see cref="IHostBuilder" />.
     /// </param>
     /// <returns>A new <see cref="LambdaApplicationFactory{TEntryPoint}" />.</returns>
-    public LambdaApplicationFactory<TEntryPoint> WithHostBuilder(Action<IHostBuilder> configuration)
-        =>
+    public LambdaApplicationFactory<TEntryPoint>
+        WithHostBuilder(Action<IHostBuilder> configuration) =>
         WithHostBuilderCore(configuration);
 
     /// <summary>
@@ -412,8 +412,9 @@ public class LambdaApplicationFactory<TEntryPoint> : IDisposable, IAsyncDisposab
             var entryPointAssemblyName = typeof(TEntryPoint).Assembly.GetName().Name;
 
             // Find the list of projects referencing TEntryPoint.
-            var candidates = context.CompileLibraries.Where(library => library.Dependencies.Any(d
-                => string.Equals(d.Name, entryPointAssemblyName, StringComparison.Ordinal)));
+            var candidates = context.CompileLibraries.Where(library =>
+                library.Dependencies.Any(d =>
+                    string.Equals(d.Name, entryPointAssemblyName, StringComparison.Ordinal)));
 
             var testAssemblies = new List<Assembly>();
             foreach (var candidate in candidates)

--- a/src/MinimalLambda.Testing/LambdaApplicationFactoryContentRootAttribute.cs
+++ b/src/MinimalLambda.Testing/LambdaApplicationFactoryContentRootAttribute.cs
@@ -62,10 +62,10 @@ public sealed class LambdaApplicationFactoryContentRootAttribute : Attribute
         ContentRootPath = contentRootPath;
         ContentRootTest = contentRootTest;
         if (int.TryParse(
-                priority,
-                NumberStyles.Integer,
-                CultureInfo.InvariantCulture,
-                out var parsedPriority))
+            priority,
+            NumberStyles.Integer,
+            CultureInfo.InvariantCulture,
+            out var parsedPriority))
             Priority = parsedPriority;
     }
 

--- a/src/MinimalLambda.Testing/LambdaTestServer.cs
+++ b/src/MinimalLambda.Testing/LambdaTestServer.cs
@@ -341,16 +341,16 @@ public class LambdaTestServer : IAsyncDisposable
 
         var response = wasSuccess && !noResponse
             ? await (responseMessage.Content?.ReadFromJsonAsync<TResponse>(
-                         _jsonSerializerOptions,
-                         cts.Token)
-                     ?? Task.FromResult<TResponse?>(default))
+                    _jsonSerializerOptions,
+                    cts.Token)
+                ?? Task.FromResult<TResponse?>(default))
             : default;
 
         var error = !wasSuccess
             ? await (responseMessage.Content?.ReadFromJsonAsync<ErrorResponse>(
-                         _jsonSerializerOptions,
-                         cts.Token)
-                     ?? Task.FromResult<ErrorResponse?>(null))
+                    _jsonSerializerOptions,
+                    cts.Token)
+                ?? Task.FromResult<ErrorResponse?>(null))
             : null;
 
         _pendingInvocations.TryRemove(requestId, out _);
@@ -417,12 +417,12 @@ public class LambdaTestServer : IAsyncDisposable
         try
         {
             await foreach (var transaction in _transactionChannel.Reader.ReadAllAsync(
-                               _shutdownCts.Token))
+                _shutdownCts.Token))
             {
                 if (!LambdaRuntimeRouteManager.TryMatch(
-                        transaction.Request,
-                        out var requestType,
-                        out var routeValues))
+                    transaction.Request,
+                    out var requestType,
+                    out var routeValues))
                     throw new InvalidOperationException(
                         $"Unexpected request received from the Lambda HTTP handler: {transaction.Request.Method} {transaction.Request.RequestUri}");
 
@@ -505,8 +505,8 @@ public class LambdaTestServer : IAsyncDisposable
                 {
                     Error =
                         await (transaction.Request.Content?.ReadFromJsonAsync<ErrorResponse>(
-                                   _jsonSerializerOptions)
-                               ?? Task.FromResult<ErrorResponse?>(null)),
+                                _jsonSerializerOptions)
+                            ?? Task.FromResult<ErrorResponse?>(null)),
                     InitStatus = InitStatus.InitError,
                 });
             return;
@@ -536,7 +536,8 @@ public class LambdaTestServer : IAsyncDisposable
 
         // Add custom Lambda runtime headers
         var deadlineMs = DateTimeOffset
-            .UtcNow.Add(_serverOptions.FunctionTimeout)
+            .UtcNow
+            .Add(_serverOptions.FunctionTimeout)
             .ToUnixTimeMilliseconds();
         response.Headers.Add("Lambda-Runtime-Deadline-Ms", deadlineMs.ToString());
         response.Headers.Add("Lambda-Runtime-Aws-Request-Id", requestId);

--- a/src/MinimalLambda/Builder/LambdaApplication.cs
+++ b/src/MinimalLambda/Builder/LambdaApplication.cs
@@ -52,9 +52,10 @@ public sealed class LambdaApplication
     /// <summary>Gets the application's logger.</summary>
     public ILogger Logger =>
         field ??= _host
-                      .Services.GetService<ILoggerFactory>()
-                      ?.CreateLogger(Environment.ApplicationName)
-                  ?? NullLogger.Instance;
+                .Services
+                .GetService<ILoggerFactory>()
+                ?.CreateLogger(Environment.ApplicationName)
+            ?? NullLogger.Instance;
 
     /// <inheritdoc />
     public ValueTask DisposeAsync() => ((IAsyncDisposable)_host).DisposeAsync();

--- a/src/MinimalLambda/Builder/LambdaApplicationBuilder.cs
+++ b/src/MinimalLambda/Builder/LambdaApplicationBuilder.cs
@@ -135,8 +135,8 @@ public sealed class LambdaApplicationBuilder : IHostApplicationBuilder
             logging.Configure(options =>
             {
                 options.ActivityTrackingOptions = ActivityTrackingOptions.SpanId
-                                                  | ActivityTrackingOptions.TraceId
-                                                  | ActivityTrackingOptions.ParentId;
+                    | ActivityTrackingOptions.TraceId
+                    | ActivityTrackingOptions.ParentId;
             });
         });
 

--- a/src/MinimalLambda/Builder/Middleware/RequestEnvelopeMiddleware.cs
+++ b/src/MinimalLambda/Builder/Middleware/RequestEnvelopeMiddleware.cs
@@ -56,10 +56,8 @@ public static class RequestEnvelopeMiddleware
 
             return application;
 
-            EnvelopeOptions GetOptions() =>
-                envelopeOptions ??= application.Services
-                    .GetRequiredService<IOptions<EnvelopeOptions>>()
-                    .Value;
+            EnvelopeOptions GetOptions() => envelopeOptions ??=
+                application.Services.GetRequiredService<IOptions<EnvelopeOptions>>().Value;
         }
     }
 }

--- a/src/MinimalLambda/Builder/Middleware/RequestEnvelopeMiddleware.cs
+++ b/src/MinimalLambda/Builder/Middleware/RequestEnvelopeMiddleware.cs
@@ -56,8 +56,9 @@ public static class RequestEnvelopeMiddleware
 
             return application;
 
-            EnvelopeOptions GetOptions() => envelopeOptions ??=
-                application.Services.GetRequiredService<IOptions<EnvelopeOptions>>().Value;
+            EnvelopeOptions GetOptions() =>
+                envelopeOptions ??=
+                    application.Services.GetRequiredService<IOptions<EnvelopeOptions>>().Value;
         }
     }
 }

--- a/src/MinimalLambda/Core/Features/DefaultEventFeature.cs
+++ b/src/MinimalLambda/Core/Features/DefaultEventFeature.cs
@@ -10,12 +10,12 @@ namespace MinimalLambda;
 internal class DefaultEventFeature<T>(ILambdaSerializer? lambdaSerializer = null) : IEventFeature<T>
 {
     private readonly ILambdaSerializer _lambdaSerializer = lambdaSerializer
-                                                           ?? throw new ArgumentNullException(
-                                                               nameof(lambdaSerializer),
-                                                               "ILambdaSerializer has not been registered. In AOT scenarios you must provide an "
-                                                               + "serializer by registering an ILambdaSerializer in the DI container. "
-                                                               + "Use AddLambdaSerializerWithContext (registers the context for you) or "
-                                                               + "manually register your serializer implementation.");
+        ?? throw new ArgumentNullException(
+            nameof(lambdaSerializer),
+            "ILambdaSerializer has not been registered. In AOT scenarios you must provide an "
+            + "serializer by registering an ILambdaSerializer in the DI container. "
+            + "Use AddLambdaSerializerWithContext (registers the context for you) or "
+            + "manually register your serializer implementation.");
 
     private T _data = default!;
     private bool _isDeserialized;

--- a/src/MinimalLambda/Core/Features/FeatureCollectionExtensions.cs
+++ b/src/MinimalLambda/Core/Features/FeatureCollectionExtensions.cs
@@ -40,8 +40,8 @@ public static class FeatureCollectionExtensions
             ArgumentNullException.ThrowIfNull(featureCollection);
 
             return featureCollection.Get<T>()
-                   ?? throw new InvalidOperationException(
-                       $"Feature of type '{typeof(T).FullName}' is not available in the collection.");
+                ?? throw new InvalidOperationException(
+                    $"Feature of type '{typeof(T).FullName}' is not available in the collection.");
         }
     }
 }

--- a/src/MinimalLambda/Core/Options/HostOptionsPostConfiguration.cs
+++ b/src/MinimalLambda/Core/Options/HostOptionsPostConfiguration.cs
@@ -17,7 +17,7 @@ internal class HostOptionsPostConfiguration : IPostConfigureOptions<HostOptions>
     public void PostConfigure(string? name, HostOptions options)
     {
         var shutdownTimeout = _lambdaHostOptions.ShutdownDuration
-                              - _lambdaHostOptions.ShutdownDurationBuffer;
+            - _lambdaHostOptions.ShutdownDurationBuffer;
 
         options.ShutdownTimeout =
             shutdownTimeout >= TimeSpan.Zero ? shutdownTimeout : TimeSpan.Zero;

--- a/src/MinimalLambda/Runtime/LambdaHandlerComposer.cs
+++ b/src/MinimalLambda/Runtime/LambdaHandlerComposer.cs
@@ -74,7 +74,7 @@ internal sealed class LambdaHandlerComposer : ILambdaHandlerFactory
                 await handler.Invoke(lambdaInvocationContext).ConfigureAwait(false);
 
                 if (lambdaInvocationContext.Features.TryGet<IResponseFeature>(
-                        out var responseFeature))
+                    out var responseFeature))
                     responseFeature.SerializeToStream(lambdaInvocationContext);
 
                 // If no serializer is provided, return an empty stream.

--- a/tests/MinimalLambda.Envelopes.UnitTests/CloudWatchLogsEnvelopeTests.cs
+++ b/tests/MinimalLambda.Envelopes.UnitTests/CloudWatchLogsEnvelopeTests.cs
@@ -59,10 +59,12 @@ public class CloudWatchLogsEnvelopeTests
         {
             envelope.AwslogsContent.LogEvents[i].MessageContent.Should().NotBeNull();
             envelope.AwslogsContent.LogEvents[i].MessageContent!
-                .Content.Should()
+                .Content
+                .Should()
                 .Be(payloads[i].Content);
             envelope.AwslogsContent.LogEvents[i].MessageContent!
-                .Priority.Should()
+                .Priority
+                .Should()
                 .Be(payloads[i].Priority);
         }
     }

--- a/tests/MinimalLambda.OpenTelemetry.UnitTests/OnShutdownOpenTelemetryExtensionsTests.cs
+++ b/tests/MinimalLambda.OpenTelemetry.UnitTests/OnShutdownOpenTelemetryExtensionsTests.cs
@@ -83,7 +83,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
         result.Should().Be(mockApp);
         mockApp.Received(1).OnShutdown(Arg.Any<LambdaShutdownDelegate>());
         mockApp
-            .Services.GetFakeLogCollector()
+            .Services
+            .GetFakeLogCollector()
             .GetSnapshot()
             .Should()
             .ContainEquivalentOf(
@@ -116,7 +117,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
         result.Should().Be(mockApp);
         mockApp.Received(1).OnShutdown(Arg.Any<LambdaShutdownDelegate>());
         mockApp
-            .Services.GetFakeLogCollector()
+            .Services
+            .GetFakeLogCollector()
             .GetSnapshot()
             .Should()
             .ContainEquivalentOf(
@@ -150,7 +152,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
         result.Should().Be(mockApp);
         mockApp.Received(1).OnShutdown(Arg.Any<LambdaShutdownDelegate>());
         mockApp
-            .Services.GetFakeLogCollector()
+            .Services
+            .GetFakeLogCollector()
             .GetSnapshot()
             .Should()
             .ContainEquivalentOf(
@@ -238,7 +241,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
         result.Should().Be(mockApp);
         mockApp.Received(1).OnShutdown(Arg.Any<LambdaShutdownDelegate>());
         mockApp
-            .Services.GetFakeLogCollector()
+            .Services
+            .GetFakeLogCollector()
             .GetSnapshot()
             .Should()
             .ContainEquivalentOf(
@@ -270,7 +274,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
         result.Should().Be(mockApp);
         mockApp.Received(1).OnShutdown(Arg.Any<LambdaShutdownDelegate>());
         mockApp
-            .Services.GetFakeLogCollector()
+            .Services
+            .GetFakeLogCollector()
             .GetSnapshot()
             .Should()
             .ContainEquivalentOf(
@@ -304,7 +309,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
         result.Should().Be(mockApp);
         mockApp.Received(1).OnShutdown(Arg.Any<LambdaShutdownDelegate>());
         mockApp
-            .Services.GetFakeLogCollector()
+            .Services
+            .GetFakeLogCollector()
             .GetSnapshot()
             .Should()
             .ContainEquivalentOf(
@@ -394,7 +400,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
         // Assert
         result.Should().Be(mockApp);
         mockApp
-            .Services.GetFakeLogCollector()
+            .Services
+            .GetFakeLogCollector()
             .GetSnapshot()
             .Should()
             .ContainEquivalentOf(
@@ -404,7 +411,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
                     Category = "MinimalLambda.OpenTelemetry",
                     Message = "OpenTelemetry meter provider force flush succeeded",
                 })
-            .And.ContainEquivalentOf(
+            .And
+            .ContainEquivalentOf(
                 new
                 {
                     Level = LogLevel.Information,
@@ -434,7 +442,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
         // Assert
         result.Should().Be(mockApp);
         mockApp
-            .Services.GetFakeLogCollector()
+            .Services
+            .GetFakeLogCollector()
             .GetSnapshot()
             .Should()
             .ContainEquivalentOf(
@@ -444,7 +453,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
                     Category = "MinimalLambda.OpenTelemetry",
                     Message = "OpenTelemetry meter provider force flush succeeded",
                 })
-            .And.ContainEquivalentOf(
+            .And
+            .ContainEquivalentOf(
                 new
                 {
                     Level = LogLevel.Information,
@@ -474,7 +484,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
         // Assert
         result.Should().Be(mockApp);
         mockApp
-            .Services.GetFakeLogCollector()
+            .Services
+            .GetFakeLogCollector()
             .GetSnapshot()
             .Should()
             .ContainEquivalentOf(
@@ -484,7 +495,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
                     Category = "MinimalLambda.OpenTelemetry",
                     Message = "OpenTelemetry meter provider force flush failed",
                 })
-            .And.ContainEquivalentOf(
+            .And
+            .ContainEquivalentOf(
                 new
                 {
                     Level = LogLevel.Information,
@@ -519,7 +531,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
         // Assert
         result.Should().Be(mockApp);
         mockApp
-            .Services.GetFakeLogCollector()
+            .Services
+            .GetFakeLogCollector()
             .GetSnapshot()
             .Should()
             .ContainEquivalentOf(
@@ -530,7 +543,8 @@ public class OnShutdownOpenTelemetryExtensionsTests
                     Message =
                         "OpenTelemetry meter provider force flush failed to complete within allocated time",
                 })
-            .And.ContainEquivalentOf(
+            .And
+            .ContainEquivalentOf(
                 new
                 {
                     Level = LogLevel.Warning,

--- a/tests/MinimalLambda.SourceGenerators.UnitTests/GeneratorTestHelpers.cs
+++ b/tests/MinimalLambda.SourceGenerators.UnitTests/GeneratorTestHelpers.cs
@@ -25,7 +25,8 @@ internal static class GeneratorTestHelpers
         var result = driver.GetRunResult();
 
         result
-            .Diagnostics.Should()
+            .Diagnostics
+            .Should()
             .BeEmpty(
                 "code should be generated without errors, but found:\n"
                 + string.Join(
@@ -37,9 +38,9 @@ internal static class GeneratorTestHelpers
         // to ensure consistent syntax tree features (e.g., InterceptorsNamespaces)
         var parseOptions = originalCompilation.SyntaxTrees.First().Options;
         var reparsedTrees = result
-            .GeneratedTrees.Select(tree => CSharpSyntaxTree.ParseText(
-                tree.GetText(),
-                (CSharpParseOptions)parseOptions))
+            .GeneratedTrees
+            .Select(tree
+                => CSharpSyntaxTree.ParseText(tree.GetText(), (CSharpParseOptions)parseOptions))
             .ToArray();
 
         // Add generated trees to original compilation
@@ -71,8 +72,8 @@ internal static class GeneratorTestHelpers
                 // [global::System.CodeDom.Compiler.GeneratedCode("MinimalLambda.SourceGenerators",
                 // "0.0.0")]
                 if (line.Contains(
-                        "global::System.CodeDom.Compiler.GeneratedCode",
-                        StringComparison.Ordinal))
+                    "global::System.CodeDom.Compiler.GeneratedCode",
+                    StringComparison.Ordinal))
                     return RegexHelper.GeneratedCodeAttributeRegex().Replace(line, "REPLACED");
 
                 // replace [InterceptsLocation(1, "")]
@@ -95,7 +96,8 @@ internal static class GeneratorTestHelpers
         ];
 
         var parseOptions = CSharpParseOptions
-            .Default.WithLanguageVersion(languageVersion)
+            .Default
+            .WithLanguageVersion(languageVersion)
             .WithFeatures(features);
 
         var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions, "InputFile.cs");

--- a/tests/MinimalLambda.SourceGenerators.UnitTests/GeneratorTestHelpers.cs
+++ b/tests/MinimalLambda.SourceGenerators.UnitTests/GeneratorTestHelpers.cs
@@ -39,8 +39,8 @@ internal static class GeneratorTestHelpers
         var parseOptions = originalCompilation.SyntaxTrees.First().Options;
         var reparsedTrees = result
             .GeneratedTrees
-            .Select(tree
-                => CSharpSyntaxTree.ParseText(tree.GetText(), (CSharpParseOptions)parseOptions))
+            .Select(tree =>
+                CSharpSyntaxTree.ParseText(tree.GetText(), (CSharpParseOptions)parseOptions))
             .ToArray();
 
         // Add generated trees to original compilation

--- a/tests/MinimalLambda.Testing.UnitTests/Tests/MinimalLambda.Testing.UnitTests/DiLambdaTests.cs
+++ b/tests/MinimalLambda.Testing.UnitTests/Tests/MinimalLambda.Testing.UnitTests/DiLambdaTests.cs
@@ -80,7 +80,9 @@ public class DiLambdaTests
         initResult.InitStatus.Should().Be(InitStatus.InitError);
         initResult.Error.Should().NotBeNull();
         initResult
-            .Error.ErrorMessage.Should()
+            .Error
+            .ErrorMessage
+            .Should()
             .Be("Encountered errors while running OnInit handlers: (Test init error)");
     }
 

--- a/tests/MinimalLambda.UnitTests/Builder/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/MinimalLambda.UnitTests/Builder/Extensions/ServiceCollectionExtensionsTests.cs
@@ -71,8 +71,9 @@ public class ServiceCollectionExtensionsTests
         serviceCollection.AddLambdaHostCoreServices();
 
         // Assert
-        var descriptor = serviceCollection.FirstOrDefault(d =>
-            d.ServiceType == typeof(ILambdaOnInitBuilderFactory));
+        var descriptor =
+            serviceCollection.FirstOrDefault(d
+                => d.ServiceType == typeof(ILambdaOnInitBuilderFactory));
         descriptor.Should().NotBeNull();
         descriptor.ImplementationType.Should().Be<DefaultLambdaOnInitBuilderFactory>();
         descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);
@@ -105,8 +106,9 @@ public class ServiceCollectionExtensionsTests
         serviceCollection.AddLambdaHostCoreServices();
 
         // Assert
-        var descriptor = serviceCollection.FirstOrDefault(d =>
-            d.ServiceType == typeof(IFeatureCollectionFactory));
+        var descriptor =
+            serviceCollection.FirstOrDefault(d
+                => d.ServiceType == typeof(IFeatureCollectionFactory));
         descriptor.Should().NotBeNull();
         descriptor.ImplementationType.Should().Be<DefaultFeatureCollectionFactory>();
         descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);
@@ -122,8 +124,8 @@ public class ServiceCollectionExtensionsTests
         serviceCollection.AddLambdaHostCoreServices();
 
         // Assert
-        var descriptor = serviceCollection.FirstOrDefault(d =>
-            d.ServiceType == typeof(ILambdaHandlerFactory));
+        var descriptor =
+            serviceCollection.FirstOrDefault(d => d.ServiceType == typeof(ILambdaHandlerFactory));
         descriptor.Should().NotBeNull();
         descriptor.ImplementationType.Should().Be<LambdaHandlerComposer>();
         descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);
@@ -241,8 +243,8 @@ public class ServiceCollectionExtensionsTests
         serviceCollection.TryAddLambdaHostDefaultServices();
 
         // Assert
-        var descriptor = serviceCollection.FirstOrDefault(d =>
-            d.ServiceType == typeof(ILambdaSerializer));
+        var descriptor =
+            serviceCollection.FirstOrDefault(d => d.ServiceType == typeof(ILambdaSerializer));
         descriptor.Should().NotBeNull();
         descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);
     }
@@ -257,8 +259,9 @@ public class ServiceCollectionExtensionsTests
         serviceCollection.TryAddLambdaHostDefaultServices();
 
         // Assert
-        var descriptor = serviceCollection.FirstOrDefault(d =>
-            d.ServiceType == typeof(ILambdaCancellationFactory));
+        var descriptor =
+            serviceCollection.FirstOrDefault(d
+                => d.ServiceType == typeof(ILambdaCancellationFactory));
         descriptor.Should().NotBeNull();
         descriptor.ImplementationType.Should().Be<DefaultLambdaCancellationFactory>();
         descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);

--- a/tests/MinimalLambda.UnitTests/Builder/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/MinimalLambda.UnitTests/Builder/Extensions/ServiceCollectionExtensionsTests.cs
@@ -72,8 +72,8 @@ public class ServiceCollectionExtensionsTests
 
         // Assert
         var descriptor =
-            serviceCollection.FirstOrDefault(d
-                => d.ServiceType == typeof(ILambdaOnInitBuilderFactory));
+            serviceCollection.FirstOrDefault(d =>
+                d.ServiceType == typeof(ILambdaOnInitBuilderFactory));
         descriptor.Should().NotBeNull();
         descriptor.ImplementationType.Should().Be<DefaultLambdaOnInitBuilderFactory>();
         descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);
@@ -107,8 +107,8 @@ public class ServiceCollectionExtensionsTests
 
         // Assert
         var descriptor =
-            serviceCollection.FirstOrDefault(d
-                => d.ServiceType == typeof(IFeatureCollectionFactory));
+            serviceCollection.FirstOrDefault(d =>
+                d.ServiceType == typeof(IFeatureCollectionFactory));
         descriptor.Should().NotBeNull();
         descriptor.ImplementationType.Should().Be<DefaultFeatureCollectionFactory>();
         descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);
@@ -260,8 +260,8 @@ public class ServiceCollectionExtensionsTests
 
         // Assert
         var descriptor =
-            serviceCollection.FirstOrDefault(d
-                => d.ServiceType == typeof(ILambdaCancellationFactory));
+            serviceCollection.FirstOrDefault(d =>
+                d.ServiceType == typeof(ILambdaCancellationFactory));
         descriptor.Should().NotBeNull();
         descriptor.ImplementationType.Should().Be<DefaultLambdaCancellationFactory>();
         descriptor.Lifetime.Should().Be(ServiceLifetime.Singleton);

--- a/tests/MinimalLambda.UnitTests/Builder/LambdaApplicationBuilderTests.cs
+++ b/tests/MinimalLambda.UnitTests/Builder/LambdaApplicationBuilderTests.cs
@@ -226,7 +226,8 @@ public class LambdaApplicationBuilderTests
 
         // Act - create a real invocation builder to verify callback applies the handler
         var invocationBuilder = app
-            .Services.GetRequiredService<ILambdaInvocationBuilderFactory>()
+            .Services
+            .GetRequiredService<ILambdaInvocationBuilderFactory>()
             .CreateBuilder();
 
         // The callback will attempt to apply the handler and middlewares
@@ -260,7 +261,8 @@ public class LambdaApplicationBuilderTests
 
         // Act - create invocation builder to verify callback applies all components
         var invocationBuilder = app
-            .Services.GetRequiredService<ILambdaInvocationBuilderFactory>()
+            .Services
+            .GetRequiredService<ILambdaInvocationBuilderFactory>()
             .CreateBuilder();
 
         // The callback should apply middlewares and properties from the app
@@ -308,7 +310,8 @@ public class LambdaApplicationBuilderTests
 
         // Act - create onInit builder to verify callback applies handlers
         var onInitBuilder = app
-            .Services.GetRequiredService<ILambdaOnInitBuilderFactory>()
+            .Services
+            .GetRequiredService<ILambdaOnInitBuilderFactory>()
             .CreateBuilder();
 
         callbackDelegate?.Invoke(onInitBuilder);
@@ -334,7 +337,8 @@ public class LambdaApplicationBuilderTests
 
         // Act - create onInit builder and invoke callback
         var onInitBuilder = app
-            .Services.GetRequiredService<ILambdaOnInitBuilderFactory>()
+            .Services
+            .GetRequiredService<ILambdaOnInitBuilderFactory>()
             .CreateBuilder();
 
         callbackDelegate?.Invoke(onInitBuilder);
@@ -356,7 +360,8 @@ public class LambdaApplicationBuilderTests
 
         // Act - create onInit builder without registering init handlers
         var onInitBuilder = app
-            .Services.GetRequiredService<ILambdaOnInitBuilderFactory>()
+            .Services
+            .GetRequiredService<ILambdaOnInitBuilderFactory>()
             .CreateBuilder();
 
         callbackDelegate?.Invoke(onInitBuilder);
@@ -398,7 +403,8 @@ public class LambdaApplicationBuilderTests
 
         // Act - create onShutdown builder to verify callback applies handlers
         var onShutdownBuilder = app
-            .Services.GetRequiredService<ILambdaOnShutdownBuilderFactory>()
+            .Services
+            .GetRequiredService<ILambdaOnShutdownBuilderFactory>()
             .CreateBuilder();
 
         callbackDelegate?.Invoke(onShutdownBuilder);
@@ -420,7 +426,8 @@ public class LambdaApplicationBuilderTests
 
         // Act - create onShutdown builder without registering shutdown handlers
         var onShutdownBuilder = app
-            .Services.GetRequiredService<ILambdaOnShutdownBuilderFactory>()
+            .Services
+            .GetRequiredService<ILambdaOnShutdownBuilderFactory>()
             .CreateBuilder();
 
         callbackDelegate?.Invoke(onShutdownBuilder);
@@ -449,7 +456,8 @@ public class LambdaApplicationBuilderTests
 
         // Act - create onShutdown builder and apply handlers
         var onShutdownBuilder = app
-            .Services.GetRequiredService<ILambdaOnShutdownBuilderFactory>()
+            .Services
+            .GetRequiredService<ILambdaOnShutdownBuilderFactory>()
             .CreateBuilder();
 
         callbackDelegate?.Invoke(onShutdownBuilder);

--- a/tests/MinimalLambda.UnitTests/Core/Options/HostOptionsPostConfigurationTests.cs
+++ b/tests/MinimalLambda.UnitTests/Core/Options/HostOptionsPostConfigurationTests.cs
@@ -36,7 +36,7 @@ public class HostOptionsPostConfigurationTests
         var postConfig = new HostOptionsPostConfiguration(lambdaHostOptions);
         var hostOptions = new HostOptions();
         var expectedTimeout = lambdaHostOptions.Value.ShutdownDuration
-                              - lambdaHostOptions.Value.ShutdownDurationBuffer;
+            - lambdaHostOptions.Value.ShutdownDurationBuffer;
 
         // Act
         postConfig.PostConfigure(null, hostOptions);
@@ -136,7 +136,7 @@ public class HostOptionsPostConfigurationTests
         var hostOptions1 = new HostOptions();
         var hostOptions2 = new HostOptions();
         var expectedTimeout = lambdaHostOptions.Value.ShutdownDuration
-                              - lambdaHostOptions.Value.ShutdownDurationBuffer;
+            - lambdaHostOptions.Value.ShutdownDurationBuffer;
 
         // Act
         postConfig.PostConfigure(null, hostOptions1);
@@ -156,7 +156,7 @@ public class HostOptionsPostConfigurationTests
         var postConfig = new HostOptionsPostConfiguration(lambdaHostOptions);
         var hostOptions = new HostOptions();
         var expectedTimeout = lambdaHostOptions.Value.ShutdownDuration
-                              - lambdaHostOptions.Value.ShutdownDurationBuffer;
+            - lambdaHostOptions.Value.ShutdownDurationBuffer;
 
         // Act
         postConfig.PostConfigure("anyName", hostOptions);


### PR DESCRIPTION
## 📋 Summary

Align JetBrains formatter settings and apply resulting indentation and wrapping rules across source and test code. Exclude agent instruction files from IDE formatting so their authored Markdown layout remains stable.

## 🔄 Changes

- Update solution formatting preferences for expression bodies, wrapping, alignment, and attribute length.
- Disable IDE formatting for `.agents/**` through `.editorconfig`.
- Apply consistent formatting across runtime, testing, source-generator, and unit-test projects.

## ✅ Validation

- `git diff --check origin/main...HEAD`
