### PR TITLE
ci(github): align required build check name

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-build:
+  build:
     uses: LayeredCraft/devops-templates/.github/workflows/pr-build.yaml@v10.1
     with:
       solution: MinimalLambda.sln


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Summary

Renames the reusable PR build caller job from `pr-build` to `build`. This makes GitHub emit the required `build / build` check name expected by `main` branch protection, allowing successful builds to satisfy auto-merge requirements.

______________________________________________________________________

## ✅ Checklist

- [ ] My changes build cleanly
- [ ] I’ve added/updated relevant tests
- [ ] I’ve added/updated documentation or README
- [x] I’ve followed the coding style for this project
- [x] I’ve tested the changes locally (if applicable)

______________________________________________________________________

## 🧪 Validation

- `git diff --check`
- Confirmed live `main` branch protection requires `build / build`
- Confirmed reusable workflow check currently appears as `pr-build / build`

______________________________________________________________________

## 💬 Notes for Reviewers

Workflow-only job identifier change. No runtime or package behavior changes.
